### PR TITLE
feat: split GitHub Pages into nav, admin config, and highway demo pages

### DIFF
--- a/apps/highway-rescue-demo/README.md
+++ b/apps/highway-rescue-demo/README.md
@@ -2,6 +2,11 @@
 
 该目录是独立于后台管理 Portal 的前端演示应用，模拟“高速事故 -> 无人机/无人狗协同救援”流程。
 
+## 页面入口（GitHub Pages）
+- `index.html`：站点导航页（统一入口）
+- `admin-config.html`：管理配置页面（管理端示意）
+- `highway-demo.html`：高速事故救援 Demo 页面
+
 ## 功能
 - Mock 事故事件触发
 - 侦查无人机、消防无人机、救援无人狗联动
@@ -18,7 +23,8 @@ python3 server.py
 ```
 
 浏览器访问：
-- http://localhost:8000
+- http://localhost:8000/index.html（导航页）
+- http://localhost:8000/highway-demo.html（高速事故 Demo）
 
 ## GitHub Pages 部署
 本仓库已提供自动部署工作流：
@@ -29,7 +35,7 @@ python3 server.py
 2. 合并包含该工作流的分支。
 3. 手动触发 workflow（或推送 `apps/highway-rescue-demo/static/` 变更）后自动发布。
 
-> 在 GitHub Pages 环境下，页面会自动切换到“浏览器 Mock 模式”，无需后端服务即可演示完整流程。
+> 在 GitHub Pages 环境下，`highway-demo.html` 会自动切换到“浏览器 Mock 模式”，无需后端服务即可演示完整流程。
 
 ## API（Mock，server.py 提供）
 - `GET /api/health`：健康检查

--- a/apps/highway-rescue-demo/static/admin-config.html
+++ b/apps/highway-rescue-demo/static/admin-config.html
@@ -1,0 +1,110 @@
+<!doctype html>
+<html lang="zh-CN">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>管理配置页面 | 企业数字员工</title>
+    <style>
+      body {
+        margin: 0;
+        font-family: "Segoe UI", "PingFang SC", "Microsoft YaHei", sans-serif;
+        background: #f5f7fd;
+        color: #22304f;
+      }
+      header {
+        background: linear-gradient(120deg, #1e4fbf, #3f73ee);
+        color: #fff;
+        padding: 18px 22px;
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+      }
+      .back {
+        color: #fff;
+        text-decoration: none;
+        border: 1px solid rgba(255,255,255,.45);
+        border-radius: 8px;
+        padding: 6px 10px;
+        font-size: 14px;
+      }
+      .container {
+        max-width: 1080px;
+        margin: 24px auto;
+        padding: 0 18px 28px;
+      }
+      .kpis {
+        display: grid;
+        grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+        gap: 12px;
+        margin-bottom: 18px;
+      }
+      .kpi {
+        background: #fff;
+        border-radius: 12px;
+        padding: 14px;
+        border: 1px solid #e4ebfa;
+      }
+      .kpi .label { color: #66759a; font-size: 13px; }
+      .kpi .value { font-size: 28px; font-weight: 700; margin-top: 8px; }
+      .panel {
+        background: #fff;
+        border-radius: 12px;
+        border: 1px solid #e4ebfa;
+        margin-bottom: 12px;
+        padding: 16px;
+      }
+      .panel h3 { margin-top: 0; }
+      table { width: 100%; border-collapse: collapse; }
+      th, td { text-align: left; padding: 10px 8px; border-bottom: 1px solid #eef2fb; font-size: 14px; }
+      th { color: #5d6f96; font-weight: 600; }
+      .status { font-weight: 600; }
+      .status.ok { color: #0f8a42; }
+      .status.warn { color: #c77a00; }
+      .btn {
+        background: #2f5de0;
+        color: #fff;
+        border: 0;
+        border-radius: 8px;
+        padding: 8px 12px;
+        cursor: pointer;
+      }
+    </style>
+  </head>
+  <body>
+    <header>
+      <div>
+        <strong>企业数字员工 · 管理配置页面</strong>
+      </div>
+      <a class="back" href="./index.html">返回导航页</a>
+    </header>
+
+    <main class="container">
+      <section class="kpis">
+        <div class="kpi"><div class="label">已接入数字员工</div><div class="value">12</div></div>
+        <div class="kpi"><div class="label">运行中任务</div><div class="value">37</div></div>
+        <div class="kpi"><div class="label">告警数（24h）</div><div class="value">3</div></div>
+        <div class="kpi"><div class="label">平均响应时间</div><div class="value">1.8s</div></div>
+      </section>
+
+      <section class="panel">
+        <h3>模块配置总览</h3>
+        <table>
+          <thead>
+            <tr><th>模块</th><th>说明</th><th>状态</th><th>操作</th></tr>
+          </thead>
+          <tbody>
+            <tr><td>员工中心</td><td>员工档案、技能绑定、权限分组</td><td class="status ok">正常</td><td><button class="btn">进入配置</button></td></tr>
+            <tr><td>任务中心</td><td>任务编排、SLA、消息通知</td><td class="status ok">正常</td><td><button class="btn">进入配置</button></td></tr>
+            <tr><td>场景编排</td><td>业务场景流、规则引擎、审批链路</td><td class="status warn">待升级</td><td><button class="btn">查看方案</button></td></tr>
+            <tr><td>运行告警</td><td>健康检查、故障告警、值班路由</td><td class="status ok">正常</td><td><button class="btn">进入配置</button></td></tr>
+          </tbody>
+        </table>
+      </section>
+
+      <section class="panel">
+        <h3>说明</h3>
+        <p>此页面用于与「高速事故救援 Demo」分离部署，作为 GitHub Pages 上独立访问的管理端入口示意页。</p>
+      </section>
+    </main>
+  </body>
+</html>

--- a/apps/highway-rescue-demo/static/highway-demo.html
+++ b/apps/highway-rescue-demo/static/highway-demo.html
@@ -1,0 +1,238 @@
+<!doctype html>
+<html lang="zh-CN">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>高速无人协同救援 Demo</title>
+    <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css" />
+    <style>
+      body { margin: 0; font-family: Arial, sans-serif; background: #f5f7fb; }
+      header { padding: 12px 16px; background: #0f4c81; color: white; display: flex; justify-content: space-between; align-items: center; }
+      .container { display: grid; grid-template-columns: 2fr 1fr; gap: 12px; padding: 12px; height: calc(100vh - 56px); box-sizing: border-box; }
+      #map { width: 100%; height: 100%; border-radius: 8px; }
+      .panel { background: white; border-radius: 8px; padding: 12px; overflow: auto; }
+      .btn { background: #0f4c81; color: white; border: 0; border-radius: 6px; padding: 8px 10px; cursor: pointer; margin-right: 8px; }
+      .btn.secondary { background: #6c757d; }
+      .mode { font-size: 12px; opacity: 0.9; margin-left: 10px; }
+      .kpi { display: grid; grid-template-columns: 1fr 1fr; gap: 8px; margin: 10px 0; }
+      .kpi div { background: #eef3fa; border-radius: 6px; padding: 8px; font-size: 14px; }
+      .log { border-bottom: 1px solid #eee; padding: 6px 0; font-size: 13px; }
+      .asset { padding: 6px 0; border-bottom: 1px dashed #ddd; }
+    </style>
+  </head>
+  <body>
+    <header>
+      <div>
+        高速无人机/无人狗协同救援 Demo（PiAgent 场景 Mock）
+        <span id="mode" class="mode">检测中...</span>
+      </div>
+      <div>
+        <button class="btn" onclick="createIncident()">触发事故事件</button>
+        <button class="btn secondary" onclick="resetDemo()">重置</button>
+      </div>
+    </header>
+
+    <div class="container">
+      <div id="map"></div>
+      <div class="panel">
+        <h3>任务态势</h3>
+        <div id="incident">当前事件：无</div>
+
+        <div class="kpi">
+          <div>在线设备：<span id="kpi-online">3</span></div>
+          <div>运行中任务：<span id="kpi-running">0</span></div>
+          <div>事故状态：<span id="kpi-status">无</span></div>
+          <div>最近更新时间：<span id="kpi-update">-</span></div>
+        </div>
+
+        <h3>设备状态</h3>
+        <div id="assets"></div>
+
+        <h3>事件日志</h3>
+        <div id="logs"></div>
+      </div>
+    </div>
+
+    <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"></script>
+    <script>
+      const BASE_LAT = 31.2304;
+      const BASE_LNG = 121.4737;
+
+      const map = L.map('map').setView([BASE_LAT, BASE_LNG], 12);
+      L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
+        maxZoom: 19,
+        attribution: '&copy; OpenStreetMap contributors'
+      }).addTo(map);
+
+      const icons = {
+        recon_drone: L.divIcon({ html: '🛰️', className: '', iconSize: [24, 24] }),
+        fire_drone: L.divIcon({ html: '🚁', className: '', iconSize: [24, 24] }),
+        rescue_dog: L.divIcon({ html: '🐕', className: '', iconSize: [24, 24] }),
+        incident: L.divIcon({ html: '🚧', className: '', iconSize: [24, 24] }),
+      };
+
+      const markers = {};
+      let mode = 'detecting';
+
+      const browserMock = {
+        state: {
+          last_updated: Date.now() / 1000,
+          incident: null,
+          assets: {
+            recon_drone: { id: 'recon_drone', type: 'recon_drone', name: '侦查无人机-01', status: '巡航中', lat: BASE_LAT + 0.02, lng: BASE_LNG - 0.03 },
+            fire_drone: { id: 'fire_drone', type: 'fire_drone', name: '消防无人机-01', status: '待命', lat: BASE_LAT - 0.01, lng: BASE_LNG + 0.02 },
+            rescue_dog: { id: 'rescue_dog', type: 'rescue_dog', name: '救援无人狗-01', status: '待命', lat: BASE_LAT - 0.015, lng: BASE_LNG - 0.01 }
+          },
+          logs: [{ ts: Date.now() / 1000, message: '浏览器内置 mock 已启动，等待事件...' }]
+        },
+        log(msg) {
+          this.state.logs.push({ ts: Date.now() / 1000, message: msg });
+          this.state.logs = this.state.logs.slice(-100);
+          this.state.last_updated = Date.now() / 1000;
+        },
+        moveAsset(assetId, targetLat, targetLng, status, duration = 8) {
+          const asset = this.state.assets[assetId];
+          const startLat = asset.lat;
+          const startLng = asset.lng;
+          const steps = Math.max(duration, 1);
+          asset.status = status;
+          let i = 0;
+          const timer = setInterval(() => {
+            i += 1;
+            const t = i / steps;
+            asset.lat = startLat + (targetLat - startLat) * t;
+            asset.lng = startLng + (targetLng - startLng) * t;
+            this.state.last_updated = Date.now() / 1000;
+            if (i >= steps) clearInterval(timer);
+          }, 1000);
+        },
+        triggerIncident(lat = BASE_LAT + (Math.random() - 0.5) * 0.02, lng = BASE_LNG + (Math.random() - 0.5) * 0.02) {
+          const incidentId = `INC-${Math.floor(Date.now() / 1000)}`;
+          this.state.incident = { id: incidentId, type: '交通事故', status: '已发现', lat, lng };
+          this.log(`${incidentId} 侦查无人机发现高速事故点。`);
+          this.moveAsset('recon_drone', lat, lng, '盘旋侦查', 5);
+
+          setTimeout(() => {
+            this.log('消防无人机启动，前往事故点灭火。');
+            this.moveAsset('fire_drone', lat + 0.0015, lng - 0.0015, '灭火作业', 7);
+          }, 3000);
+
+          setTimeout(() => {
+            this.log('救援无人狗前往事故点，执行现场救援与伤员定位。');
+            this.moveAsset('rescue_dog', lat - 0.001, lng + 0.001, '现场搜救', 9);
+          }, 6000);
+
+          setTimeout(() => {
+            if (this.state.incident) this.state.incident.status = '处置中';
+            this.log('事故处置进行中：火情受控，救援进展正常。');
+          }, 12000);
+
+          setTimeout(() => {
+            if (this.state.incident) this.state.incident.status = '已完成';
+            this.state.assets.recon_drone.status = '返航';
+            this.state.assets.fire_drone.status = '返航';
+            this.state.assets.rescue_dog.status = '待命';
+            this.log('事故处置完成，设备返航/待命，任务闭环结束。');
+          }, 20000);
+        },
+        reset() {
+          this.state.incident = null;
+          this.state.assets.recon_drone = { id: 'recon_drone', type: 'recon_drone', name: '侦查无人机-01', status: '巡航中', lat: BASE_LAT + 0.02, lng: BASE_LNG - 0.03 };
+          this.state.assets.fire_drone = { id: 'fire_drone', type: 'fire_drone', name: '消防无人机-01', status: '待命', lat: BASE_LAT - 0.01, lng: BASE_LNG + 0.02 };
+          this.state.assets.rescue_dog = { id: 'rescue_dog', type: 'rescue_dog', name: '救援无人狗-01', status: '待命', lat: BASE_LAT - 0.015, lng: BASE_LNG - 0.01 };
+          this.log('系统已重置。');
+        }
+      };
+
+      function setMode(m) {
+        mode = m;
+        document.getElementById('mode').innerText = m === 'api' ? '模式：后端 API 模式' : '模式：GitHub Pages 浏览器 Mock 模式';
+      }
+
+      async function detectMode() {
+        try {
+          const controller = new AbortController();
+          const timeout = setTimeout(() => controller.abort(), 1000);
+          const r = await fetch('/api/health', { signal: controller.signal });
+          clearTimeout(timeout);
+          if (r.ok) return setMode('api');
+        } catch (_) {}
+        setMode('browser-mock');
+      }
+
+      function upsertMarker(id, lat, lng, icon, popup) {
+        if (!markers[id]) {
+          markers[id] = L.marker([lat, lng], { icon }).addTo(map);
+        } else {
+          markers[id].setLatLng([lat, lng]);
+        }
+        markers[id].bindPopup(popup);
+      }
+
+      async function getState() {
+        if (mode === 'api') {
+          const res = await fetch('/api/state');
+          return res.json();
+        }
+        return browserMock.state;
+      }
+
+      async function fetchState() {
+        const data = await getState();
+        const incidentEl = document.getElementById('incident');
+        const assetsEl = document.getElementById('assets');
+        const logsEl = document.getElementById('logs');
+
+        const assets = Object.values(data.assets || {});
+        let running = 0;
+        assetsEl.innerHTML = assets.map(a => {
+          if (!["待命", "巡航中", "返航"].includes(a.status)) running += 1;
+          upsertMarker(a.id, a.lat, a.lng, icons[a.type], `${a.name}<br/>${a.status}`);
+          return `<div class="asset"><strong>${a.name}</strong><br/>状态：${a.status}<br/>坐标：${a.lat.toFixed(5)}, ${a.lng.toFixed(5)}</div>`;
+        }).join('');
+
+        if (data.incident) {
+          const i = data.incident;
+          incidentEl.innerText = `当前事件：${i.id}（${i.type}）状态：${i.status}`;
+          upsertMarker('incident', i.lat, i.lng, icons.incident, `${i.id}<br/>${i.status}`);
+          document.getElementById('kpi-status').innerText = i.status;
+        } else {
+          incidentEl.innerText = '当前事件：无';
+          document.getElementById('kpi-status').innerText = '无';
+        }
+
+        document.getElementById('kpi-running').innerText = String(running);
+        document.getElementById('kpi-online').innerText = String(assets.length);
+        document.getElementById('kpi-update').innerText = new Date(data.last_updated * 1000).toLocaleTimeString();
+
+        logsEl.innerHTML = (data.logs || []).slice().reverse().slice(0, 20).map(l =>
+          `<div class="log">[${new Date(l.ts * 1000).toLocaleTimeString()}] ${l.message}</div>`
+        ).join('');
+      }
+
+      async function createIncident() {
+        if (mode === 'api') {
+          await fetch('/api/incidents/mock', { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: '{}' });
+        } else {
+          browserMock.triggerIncident();
+        }
+        await fetchState();
+      }
+
+      async function resetDemo() {
+        if (mode === 'api') {
+          await fetch('/api/reset', { method: 'POST' });
+        } else {
+          browserMock.reset();
+        }
+        await fetchState();
+      }
+
+      (async () => {
+        await detectMode();
+        await fetchState();
+        setInterval(fetchState, 1000);
+      })();
+    </script>
+  </body>
+</html>

--- a/apps/highway-rescue-demo/static/index.html
+++ b/apps/highway-rescue-demo/static/index.html
@@ -3,236 +3,121 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>高速无人协同救援 Demo</title>
-    <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css" />
+    <title>企业数字员工导航中心</title>
     <style>
-      body { margin: 0; font-family: Arial, sans-serif; background: #f5f7fb; }
-      header { padding: 12px 16px; background: #0f4c81; color: white; display: flex; justify-content: space-between; align-items: center; }
-      .container { display: grid; grid-template-columns: 2fr 1fr; gap: 12px; padding: 12px; height: calc(100vh - 56px); box-sizing: border-box; }
-      #map { width: 100%; height: 100%; border-radius: 8px; }
-      .panel { background: white; border-radius: 8px; padding: 12px; overflow: auto; }
-      .btn { background: #0f4c81; color: white; border: 0; border-radius: 6px; padding: 8px 10px; cursor: pointer; margin-right: 8px; }
-      .btn.secondary { background: #6c757d; }
-      .mode { font-size: 12px; opacity: 0.9; margin-left: 10px; }
-      .kpi { display: grid; grid-template-columns: 1fr 1fr; gap: 8px; margin: 10px 0; }
-      .kpi div { background: #eef3fa; border-radius: 6px; padding: 8px; font-size: 14px; }
-      .log { border-bottom: 1px solid #eee; padding: 6px 0; font-size: 13px; }
-      .asset { padding: 6px 0; border-bottom: 1px dashed #ddd; }
+      :root {
+        --bg: #f3f7ff;
+        --card: #ffffff;
+        --text: #1f2a44;
+        --subtle: #5f6f8f;
+        --primary: #2b5bd7;
+        --primary-dark: #1f45ab;
+        --shadow: 0 10px 30px rgba(25, 52, 110, 0.12);
+      }
+      * { box-sizing: border-box; }
+      body {
+        margin: 0;
+        font-family: "Segoe UI", "PingFang SC", "Microsoft YaHei", sans-serif;
+        background: radial-gradient(circle at top, #eaf1ff 0%, var(--bg) 42%, #eef2fb 100%);
+        color: var(--text);
+        min-height: 100vh;
+      }
+      .wrap {
+        max-width: 980px;
+        margin: 0 auto;
+        padding: 64px 20px 48px;
+      }
+      .hero {
+        text-align: center;
+        margin-bottom: 36px;
+      }
+      .hero h1 {
+        margin: 0 0 12px;
+        font-size: clamp(28px, 4vw, 40px);
+      }
+      .hero p {
+        margin: 0;
+        color: var(--subtle);
+        font-size: 16px;
+      }
+      .grid {
+        display: grid;
+        gap: 18px;
+        grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+      }
+      .card {
+        background: var(--card);
+        border-radius: 16px;
+        padding: 22px;
+        box-shadow: var(--shadow);
+        border: 1px solid #e4ebfb;
+      }
+      .card h2 {
+        margin-top: 0;
+        margin-bottom: 10px;
+        font-size: 21px;
+      }
+      .card p {
+        margin-top: 0;
+        color: var(--subtle);
+        line-height: 1.6;
+        min-height: 56px;
+      }
+      .meta {
+        font-size: 13px;
+        color: #7484a8;
+        margin-bottom: 16px;
+      }
+      .btn {
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        gap: 8px;
+        width: 100%;
+        text-decoration: none;
+        border-radius: 10px;
+        padding: 11px 14px;
+        color: white;
+        background: linear-gradient(135deg, var(--primary), #4a74e5);
+        font-weight: 600;
+        transition: transform .2s ease, background .2s ease;
+      }
+      .btn:hover {
+        transform: translateY(-1px);
+        background: linear-gradient(135deg, var(--primary-dark), #3b67de);
+      }
+      footer {
+        text-align: center;
+        color: #7886a6;
+        font-size: 13px;
+        margin-top: 30px;
+      }
     </style>
   </head>
   <body>
-    <header>
-      <div>
-        高速无人机/无人狗协同救援 Demo（PiAgent 场景 Mock）
-        <span id="mode" class="mode">检测中...</span>
-      </div>
-      <div>
-        <button class="btn" onclick="createIncident()">触发事故事件</button>
-        <button class="btn secondary" onclick="resetDemo()">重置</button>
-      </div>
-    </header>
+    <main class="wrap">
+      <section class="hero">
+        <h1>企业数字员工站点导航</h1>
+        <p>将「管理配置页面」与「高速事故 Demo」分离，便于在 GitHub Pages 独立访问与演示。</p>
+      </section>
 
-    <div class="container">
-      <div id="map"></div>
-      <div class="panel">
-        <h3>任务态势</h3>
-        <div id="incident">当前事件：无</div>
+      <section class="grid">
+        <article class="card">
+          <h2>管理配置页面</h2>
+          <p>用于展示企业数字员工后台管理与配置入口，包含管理指标、模块列表与后续集成说明。</p>
+          <div class="meta">路径：<code>/admin-config.html</code></div>
+          <a class="btn" href="./admin-config.html">进入管理配置页面</a>
+        </article>
 
-        <div class="kpi">
-          <div>在线设备：<span id="kpi-online">3</span></div>
-          <div>运行中任务：<span id="kpi-running">0</span></div>
-          <div>事故状态：<span id="kpi-status">无</span></div>
-          <div>最近更新时间：<span id="kpi-update">-</span></div>
-        </div>
+        <article class="card">
+          <h2>高速事故救援 Demo</h2>
+          <p>无人机 / 无人狗协同救援可视化演示，支持 GitHub Pages 浏览器 Mock 与后端 API 模式。</p>
+          <div class="meta">路径：<code>/highway-demo.html</code></div>
+          <a class="btn" href="./highway-demo.html">进入高速事故 Demo</a>
+        </article>
+      </section>
 
-        <h3>设备状态</h3>
-        <div id="assets"></div>
-
-        <h3>事件日志</h3>
-        <div id="logs"></div>
-      </div>
-    </div>
-
-    <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"></script>
-    <script>
-      const BASE_LAT = 31.2304;
-      const BASE_LNG = 121.4737;
-
-      const map = L.map('map').setView([BASE_LAT, BASE_LNG], 12);
-      L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
-        maxZoom: 19,
-        attribution: '&copy; OpenStreetMap contributors'
-      }).addTo(map);
-
-      const icons = {
-        recon_drone: L.divIcon({ html: '🛰️', className: '', iconSize: [24, 24] }),
-        fire_drone: L.divIcon({ html: '🚁', className: '', iconSize: [24, 24] }),
-        rescue_dog: L.divIcon({ html: '🐕', className: '', iconSize: [24, 24] }),
-        incident: L.divIcon({ html: '🚧', className: '', iconSize: [24, 24] }),
-      };
-
-      const markers = {};
-      let mode = 'detecting';
-
-      const browserMock = {
-        state: {
-          last_updated: Date.now() / 1000,
-          incident: null,
-          assets: {
-            recon_drone: { id: 'recon_drone', type: 'recon_drone', name: '侦查无人机-01', status: '巡航中', lat: BASE_LAT + 0.02, lng: BASE_LNG - 0.03 },
-            fire_drone: { id: 'fire_drone', type: 'fire_drone', name: '消防无人机-01', status: '待命', lat: BASE_LAT - 0.01, lng: BASE_LNG + 0.02 },
-            rescue_dog: { id: 'rescue_dog', type: 'rescue_dog', name: '救援无人狗-01', status: '待命', lat: BASE_LAT - 0.015, lng: BASE_LNG - 0.01 }
-          },
-          logs: [{ ts: Date.now() / 1000, message: '浏览器内置 mock 已启动，等待事件...' }]
-        },
-        log(msg) {
-          this.state.logs.push({ ts: Date.now() / 1000, message: msg });
-          this.state.logs = this.state.logs.slice(-100);
-          this.state.last_updated = Date.now() / 1000;
-        },
-        moveAsset(assetId, targetLat, targetLng, status, duration = 8) {
-          const asset = this.state.assets[assetId];
-          const startLat = asset.lat;
-          const startLng = asset.lng;
-          const steps = Math.max(duration, 1);
-          asset.status = status;
-          let i = 0;
-          const timer = setInterval(() => {
-            i += 1;
-            const t = i / steps;
-            asset.lat = startLat + (targetLat - startLat) * t;
-            asset.lng = startLng + (targetLng - startLng) * t;
-            this.state.last_updated = Date.now() / 1000;
-            if (i >= steps) clearInterval(timer);
-          }, 1000);
-        },
-        triggerIncident(lat = BASE_LAT + (Math.random() - 0.5) * 0.02, lng = BASE_LNG + (Math.random() - 0.5) * 0.02) {
-          const incidentId = `INC-${Math.floor(Date.now() / 1000)}`;
-          this.state.incident = { id: incidentId, type: '交通事故', status: '已发现', lat, lng };
-          this.log(`${incidentId} 侦查无人机发现高速事故点。`);
-          this.moveAsset('recon_drone', lat, lng, '盘旋侦查', 5);
-
-          setTimeout(() => {
-            this.log('消防无人机启动，前往事故点灭火。');
-            this.moveAsset('fire_drone', lat + 0.0015, lng - 0.0015, '灭火作业', 7);
-          }, 3000);
-
-          setTimeout(() => {
-            this.log('救援无人狗前往事故点，执行现场救援与伤员定位。');
-            this.moveAsset('rescue_dog', lat - 0.001, lng + 0.001, '现场搜救', 9);
-          }, 6000);
-
-          setTimeout(() => {
-            if (this.state.incident) this.state.incident.status = '处置中';
-            this.log('事故处置进行中：火情受控，救援进展正常。');
-          }, 12000);
-
-          setTimeout(() => {
-            if (this.state.incident) this.state.incident.status = '已完成';
-            this.state.assets.recon_drone.status = '返航';
-            this.state.assets.fire_drone.status = '返航';
-            this.state.assets.rescue_dog.status = '待命';
-            this.log('事故处置完成，设备返航/待命，任务闭环结束。');
-          }, 20000);
-        },
-        reset() {
-          this.state.incident = null;
-          this.state.assets.recon_drone = { id: 'recon_drone', type: 'recon_drone', name: '侦查无人机-01', status: '巡航中', lat: BASE_LAT + 0.02, lng: BASE_LNG - 0.03 };
-          this.state.assets.fire_drone = { id: 'fire_drone', type: 'fire_drone', name: '消防无人机-01', status: '待命', lat: BASE_LAT - 0.01, lng: BASE_LNG + 0.02 };
-          this.state.assets.rescue_dog = { id: 'rescue_dog', type: 'rescue_dog', name: '救援无人狗-01', status: '待命', lat: BASE_LAT - 0.015, lng: BASE_LNG - 0.01 };
-          this.log('系统已重置。');
-        }
-      };
-
-      function setMode(m) {
-        mode = m;
-        document.getElementById('mode').innerText = m === 'api' ? '模式：后端 API 模式' : '模式：GitHub Pages 浏览器 Mock 模式';
-      }
-
-      async function detectMode() {
-        try {
-          const controller = new AbortController();
-          const timeout = setTimeout(() => controller.abort(), 1000);
-          const r = await fetch('/api/health', { signal: controller.signal });
-          clearTimeout(timeout);
-          if (r.ok) return setMode('api');
-        } catch (_) {}
-        setMode('browser-mock');
-      }
-
-      function upsertMarker(id, lat, lng, icon, popup) {
-        if (!markers[id]) {
-          markers[id] = L.marker([lat, lng], { icon }).addTo(map);
-        } else {
-          markers[id].setLatLng([lat, lng]);
-        }
-        markers[id].bindPopup(popup);
-      }
-
-      async function getState() {
-        if (mode === 'api') {
-          const res = await fetch('/api/state');
-          return res.json();
-        }
-        return browserMock.state;
-      }
-
-      async function fetchState() {
-        const data = await getState();
-        const incidentEl = document.getElementById('incident');
-        const assetsEl = document.getElementById('assets');
-        const logsEl = document.getElementById('logs');
-
-        const assets = Object.values(data.assets || {});
-        let running = 0;
-        assetsEl.innerHTML = assets.map(a => {
-          if (!["待命", "巡航中", "返航"].includes(a.status)) running += 1;
-          upsertMarker(a.id, a.lat, a.lng, icons[a.type], `${a.name}<br/>${a.status}`);
-          return `<div class="asset"><strong>${a.name}</strong><br/>状态：${a.status}<br/>坐标：${a.lat.toFixed(5)}, ${a.lng.toFixed(5)}</div>`;
-        }).join('');
-
-        if (data.incident) {
-          const i = data.incident;
-          incidentEl.innerText = `当前事件：${i.id}（${i.type}）状态：${i.status}`;
-          upsertMarker('incident', i.lat, i.lng, icons.incident, `${i.id}<br/>${i.status}`);
-          document.getElementById('kpi-status').innerText = i.status;
-        } else {
-          incidentEl.innerText = '当前事件：无';
-          document.getElementById('kpi-status').innerText = '无';
-        }
-
-        document.getElementById('kpi-running').innerText = String(running);
-        document.getElementById('kpi-online').innerText = String(assets.length);
-        document.getElementById('kpi-update').innerText = new Date(data.last_updated * 1000).toLocaleTimeString();
-
-        logsEl.innerHTML = (data.logs || []).slice().reverse().slice(0, 20).map(l =>
-          `<div class="log">[${new Date(l.ts * 1000).toLocaleTimeString()}] ${l.message}</div>`
-        ).join('');
-      }
-
-      async function createIncident() {
-        if (mode === 'api') {
-          await fetch('/api/incidents/mock', { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: '{}' });
-        } else {
-          browserMock.triggerIncident();
-        }
-        await fetchState();
-      }
-
-      async function resetDemo() {
-        if (mode === 'api') {
-          await fetch('/api/reset', { method: 'POST' });
-        } else {
-          browserMock.reset();
-        }
-        await fetchState();
-      }
-
-      (async () => {
-        await detectMode();
-        await fetchState();
-        setInterval(fetchState, 1000);
-      })();
-    </script>
+      <footer>EnterpriseDigitalEmployee · GitHub Pages Navigation</footer>
+    </main>
   </body>
 </html>


### PR DESCRIPTION
### Motivation
- Separate the management/configuration UI from the highway accident demo so each can be independently published and accessed via GitHub Pages, and provide a nicer unified navigation entry for end users.

### Description
- Replaced the previous single demo page with a styled navigation landing at `apps/highway-rescue-demo/static/index.html` linking to the two independent pages.
- Added `apps/highway-rescue-demo/static/admin-config.html` as a standalone management/configuration mock page for the admin view.
- Extracted the demo UI into `apps/highway-rescue-demo/static/highway-demo.html` while preserving the existing map and mock incident logic.
- Updated `apps/highway-rescue-demo/README.md` to document the new page entry points and local/GitHub Pages access paths.

### Testing
- Ran `python3 -m py_compile apps/highway-rescue-demo/server.py` which completed successfully.
- Served the static files with `python3 -m http.server 4173 --directory apps/highway-rescue-demo/static` and executed a Playwright script to load `index.html` and capture a screenshot, which completed and produced a screenshot artifact.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b800ce56c4832fa39de7a24b5e103a)