### PR TITLE
ci: add project-wide GitHub Actions smoke checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,115 @@
+name: CI Checks
+
+on:
+  pull_request:
+  push:
+    branches: ["main", "master", "work"]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  python-compile:
+    name: Python Syntax Check
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Compile Python files
+        run: python -m compileall apps
+
+  smoke-highway-rescue-demo:
+    name: Smoke Test Highway Rescue Demo
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Start server
+        run: |
+          python apps/highway-rescue-demo/server.py > /tmp/highway-server.log 2>&1 &
+          echo $! > /tmp/highway-server.pid
+
+      - name: Wait for server
+        run: |
+          for i in {1..20}; do
+            if curl -fsS http://127.0.0.1:8000/api/health > /dev/null; then
+              exit 0
+            fi
+            sleep 1
+          done
+          echo "server not ready"
+          cat /tmp/highway-server.log
+          exit 1
+
+      - name: API smoke checks
+        run: |
+          curl -fsS http://127.0.0.1:8000/api/health
+          curl -fsS http://127.0.0.1:8000/api/state
+          curl -fsS -X POST http://127.0.0.1:8000/api/incidents/mock -H 'Content-Type: application/json' -d '{}'
+          curl -fsS -X POST http://127.0.0.1:8000/api/reset -H 'Content-Type: application/json' -d '{}'
+
+      - name: Stop server
+        if: always()
+        run: |
+          kill "$(cat /tmp/highway-server.pid)" || true
+          sleep 1
+          cat /tmp/highway-server.log || true
+
+  smoke-mvp-core:
+    name: Smoke Test MVP Core
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Start server
+        run: |
+          python apps/mvp-core/server.py > /tmp/mvp-core.log 2>&1 &
+          echo $! > /tmp/mvp-core.pid
+
+      - name: Wait for server
+        run: |
+          for i in {1..20}; do
+            if curl -fsS http://127.0.0.1:8100/api/health > /dev/null; then
+              exit 0
+            fi
+            sleep 1
+          done
+          echo "server not ready"
+          cat /tmp/mvp-core.log
+          exit 1
+
+      - name: API smoke checks
+        run: |
+          curl -fsS http://127.0.0.1:8100/api/health
+          curl -fsS http://127.0.0.1:8100/api/employees
+          curl -fsS http://127.0.0.1:8100/api/tasks
+          task_id=$(curl -fsS -X POST http://127.0.0.1:8100/api/tasks -H 'Content-Type: application/json' -d '{}' | python -c 'import json,sys; print(json.load(sys.stdin)["id"])')
+          curl -fsS "http://127.0.0.1:8100/api/tasks/${task_id}"
+          curl -fsS http://127.0.0.1:8100/api/scenario
+          curl -fsS -X POST http://127.0.0.1:8100/api/scenario/reset -H 'Content-Type: application/json' -d '{}'
+
+      - name: Stop server
+        if: always()
+        run: |
+          kill "$(cat /tmp/mvp-core.pid)" || true
+          sleep 1
+          cat /tmp/mvp-core.log || true

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@
 
 ## 部署
 - `apps/highway-rescue-demo/` 已支持 GitHub Pages 自动部署（见 `.github/workflows/deploy-highway-demo-pages.yml`）
+- 新增全仓 CI 工作流：`.github/workflows/ci.yml`（Python 语法检查 + 两个 Demo 服务 API 冒烟检查）
 
 
 ## 核心 MVP 运行入口


### PR DESCRIPTION
### Motivation

- Provide a baseline automated CI to ensure the demo apps and core services remain runnable and that the repository can be driven by CI rather than only manual checks.
- Capture basic Python syntax issues and exercise key HTTP APIs of the two demo services so regressions are caught early.

### Description

- Add `.github/workflows/ci.yml` with three jobs: `python-compile` (runs `python -m compileall apps`) and two smoke jobs that start each demo service and exercise their HTTP APIs (`/api/health`, `/api/state`, incident trigger/reset for `highway-rescue-demo`; `employees`, `tasks`, task creation, `scenario` and reset for `mvp-core`).
- Update `README.md` deployment section to document the new CI workflow and its coverage.
- Commit and prepare the PR including the new workflow and README update.

### Testing

- Ran `python -m compileall apps` locally and it completed successfully.
- Executed the smoke scripts that start `apps/highway-rescue-demo/server.py` and `apps/mvp-core/server.py` and attempted the curl-based API checks; the scripts ran but the local sandbox environment prevented reliable localhost connections so some curl attempts could not connect (this is an environment constraint, the workflow exercises the same checks on GitHub-hosted runners where binding to localhost is allowed).
- Files were added and committed (`.github/workflows/ci.yml`, updated `README.md`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b8019447ec832fa8701c82893227fb)