### PR TITLE
ci: split GitHub Pages workflow into build and deploy jobs

### DIFF
--- a/.github/workflows/deploy-highway-demo-pages.yml
+++ b/.github/workflows/deploy-highway-demo-pages.yml
@@ -6,6 +6,10 @@ on:
     paths:
       - "apps/highway-rescue-demo/static/**"
       - ".github/workflows/deploy-highway-demo-pages.yml"
+  pull_request:
+    paths:
+      - "apps/highway-rescue-demo/static/**"
+      - ".github/workflows/deploy-highway-demo-pages.yml"
   workflow_dispatch:
 
 permissions:
@@ -18,10 +22,7 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
-  deploy:
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
+  build:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -35,6 +36,14 @@ jobs:
         with:
           path: apps/highway-rescue-demo/static
 
+  deploy:
+    if: github.event_name != 'pull_request'
+    needs: build
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    steps:
       - name: Deploy to GitHub Pages
         id: deployment
         uses: actions/deploy-pages@v4

--- a/apps/highway-rescue-demo/README.md
+++ b/apps/highway-rescue-demo/README.md
@@ -34,6 +34,11 @@ python3 server.py
 本仓库已提供自动部署工作流：
 - `.github/workflows/deploy-highway-demo-pages.yml`
 
+工作流行为：
+- `pull_request`：仅执行构建与 Pages artifact 上传校验（不实际发布）
+- `push` 到 `main/master/work`：自动发布到 GitHub Pages
+- `workflow_dispatch`：可手动触发发布
+
 启用方式：
 1. 在 GitHub 仓库 Settings -> Pages 中将 Source 设为 **GitHub Actions**。
 2. 合并包含该工作流的分支。


### PR DESCRIPTION
### Motivation
- Add PR-time validation for GitHub Pages artifact builds without allowing pull requests to publish content to Pages.
- Preserve existing behavior for `push` and `workflow_dispatch` so actual publishes still occur on merge or manual trigger.

### Description
- Add a `pull_request` trigger scoped to `apps/highway-rescue-demo/static/**` and the workflow file to run validation on PRs.
- Split the single `deploy` job into `build` (checkout + configure-pages + upload artifact) and `deploy` jobs to separate build/upload from actual publishing.
- Add `if: github.event_name != 'pull_request'` and `needs: build` to the `deploy` job so PR runs stop after artifact upload while pushes and manual runs still publish.
- Update `apps/highway-rescue-demo/README.md` to document the three workflow behaviors (`pull_request` validation, `push` publish, `workflow_dispatch` manual publish).

### Testing
- No automated CI jobs were executed in this environment; the change is designed to be exercised by GitHub Actions where the new `build` job will run on pull requests and the `deploy` job will run on push or `workflow_dispatch` as configured.
- Local validation consisted of reviewing the modified workflow and ensuring the changes apply cleanly to the repository (diff/commit performed successfully).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b804df5700832f9874c3c28e050199)