### PR TITLE
feat(pages): expose /demo and /admin navigation routes

### DIFF
--- a/apps/highway-rescue-demo/static/admin/index.html
+++ b/apps/highway-rescue-demo/static/admin/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="zh-CN">
+  <head>
+    <meta charset="UTF-8" />
+    <meta http-equiv="refresh" content="0; url=../adminconsole/" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Redirecting to AdminConsole...</title>
+  </head>
+  <body>
+    <p>页面已迁移到 <a href="../adminconsole/">../adminconsole/</a>。</p>
+  </body>
+</html>

--- a/apps/highway-rescue-demo/static/index.html
+++ b/apps/highway-rescue-demo/static/index.html
@@ -74,14 +74,14 @@
   <body>
     <main class="container">
       <h1>Enterprise Digital Employee</h1>
-      <p>统一导航页：将 Demo 与 AdminConsole 拆分为独立目录与独立入口，但保持一致的 Vue + ESM 前端技术架构。</p>
+      <p>统一导航页：首页提供 /demo 与 /admin 两个入口，分别路由到演示系统与管理控制台。</p>
 
       <section class="grid">
         <article class="card">
           <h2>Highway Rescue Demo</h2>
           <p>高速事故无人机/无人狗协同救援演示页面，包含地图态势、事件推演与设备状态。</p>
           <div class="actions">
-            <a class="btn" href="./demo/">进入 Demo</a>
+            <a class="btn" href="./demo/">进入 /demo</a>
             <a class="btn secondary" href="./demo/index.html">直接打开 index.html</a>
           </div>
         </article>
@@ -90,7 +90,7 @@
           <h2>AdminConsole</h2>
           <p>管理控制台页面，采用与 Demo 相同的 Vue ESM 架构，展示配置、策略与系统状态管理能力。</p>
           <div class="actions">
-            <a class="btn" href="./adminconsole/">进入 AdminConsole</a>
+            <a class="btn" href="./admin/">进入 /admin</a>
             <a class="btn secondary" href="./adminconsole/index.html">直接打开 index.html</a>
           </div>
         </article>


### PR DESCRIPTION
### Motivation
- 将 GitHub Pages 的首页从“帮助页”调整为导航页，明确提供指向演示与管理控制台的路由入口 `/demo` 与 `/admin`，以便直接访问两个子应用。  
- 保持现有 `adminconsole` 目录不变的同时提供更友好的 `/admin` 别名以兼容常见访问习惯。 

### Description
- 更新 `apps/highway-rescue-demo/static/index.html` 的首页文案，将导航文案改为明确显示 `/demo` 与 `/admin` 并把 Admin 主按钮的 `href` 改为 `./admin/`。  
- 新增 `apps/highway-rescue-demo/static/admin/index.html` 作为 `/admin` 路由别名页面，内含立即重定向到现有 `../adminconsole/` 的 meta 重定向。  
- 本次修改仅涉及静态页面改动，无后端或构建脚本变更。 

### Testing
- 已用 `python3 -m http.server 4173 --directory apps/highway-rescue-demo/static` 启动本地静态服务器并通过 `curl -I http://127.0.0.1:4173/` 与 `curl -I http://127.0.0.1:4173/admin/` 验证两路由均返回 HTTP 200，测试通过。  
- 使用 Playwright 脚本截取了首页截图以验证视觉和链接变更，脚本运行成功并产出截图工件。  
- 已将变更提交到仓库，相关文件为 `apps/highway-rescue-demo/static/index.html` 与 `apps/highway-rescue-demo/static/admin/index.html`。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b80545a738832fbfe989c4d26fef33)