### PR TITLE
feat(connector_hub): ConnectorHub — unified connector registry with CLI support

### DIFF
--- a/apps/connector_hub/__init__.py
+++ b/apps/connector_hub/__init__.py
@@ -1,0 +1,5 @@
+"""ConnectorHub — unified connector registry and invocation layer."""
+
+from __future__ import annotations
+
+__version__ = "0.1.0"

--- a/apps/connector_hub/config.py
+++ b/apps/connector_hub/config.py
@@ -1,0 +1,17 @@
+"""ConnectorHub configuration."""
+
+from __future__ import annotations
+
+from common.config import BaseSettings
+
+
+class ConnectorHubSettings(BaseSettings):
+    """ConnectorHub settings."""
+
+    model_config = {"env_prefix": "CONNECTORHUB_", "extra": "ignore"}
+
+    host: str = "127.0.0.1"
+    port: int = 8003
+    default_timeout_seconds: int = 120
+    max_concurrent_invocations: int = 50
+    health_check_interval_seconds: int = 60

--- a/apps/connector_hub/connectors/__init__.py
+++ b/apps/connector_hub/connectors/__init__.py
@@ -1,0 +1,7 @@
+"""ConnectorHub connectors."""
+
+from __future__ import annotations
+
+from apps.connector_hub.connectors.base import Connector
+
+__all__ = ["Connector"]

--- a/apps/connector_hub/connectors/base.py
+++ b/apps/connector_hub/connectors/base.py
@@ -1,0 +1,65 @@
+"""Abstract base class for connectors."""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from typing import Any, Dict, List
+
+from apps.connector_hub.models import Capability, ConnectorInfo, ConnectorType
+
+
+class Connector(ABC):
+    """Abstract connector interface.
+
+    Each connector wraps a specific integration mechanism:
+    CLI (PiAgentClient), MCP, API, or custom.
+    """
+
+    @property
+    @abstractmethod
+    def id(self) -> str:
+        """Unique connector ID."""
+
+    @property
+    @abstractmethod
+    def name(self) -> str:
+        """Human-readable connector name."""
+
+    @property
+    @abstractmethod
+    def description(self) -> str:
+        """Description of what this connector does."""
+
+    @property
+    @abstractmethod
+    def type(self) -> ConnectorType:
+        """Connector type (cli, mcp, api, cu)."""
+
+    @abstractmethod
+    def list_capabilities(self) -> List[Capability]:
+        """Return all capabilities this connector supports."""
+
+    @abstractmethod
+    async def invoke(
+        self,
+        capability: str,
+        parameters: Dict[str, Any],
+        timeout_seconds: int = 120,
+    ) -> Any:
+        """Invoke a capability with given parameters."""
+
+    @abstractmethod
+    async def health_check(self) -> bool:
+        """Return True if the connector is reachable and healthy."""
+
+    def to_info(self) -> ConnectorInfo:
+        """Return a ConnectorInfo descriptor for this connector."""
+        return ConnectorInfo(
+            id=self.id,
+            name=self.name,
+            description=self.description,
+            type=self.type,
+            capabilities=self.list_capabilities(),
+            healthy=True,
+            config={},
+        )

--- a/apps/connector_hub/connectors/cli.py
+++ b/apps/connector_hub/connectors/cli.py
@@ -1,0 +1,132 @@
+"""CLI connector — wraps PiAgentClient from apps.runtime.piagent_client."""
+
+from __future__ import annotations
+
+import asyncio
+import time
+from typing import Any
+
+from apps.connector_hub.connectors.base import Connector
+from apps.connector_hub.errors import (
+    ConnectorCapabilityNotFoundError,
+    ConnectorExecutionFailedError,
+    ConnectorTimeoutError,
+)
+from apps.connector_hub.models import Capability, ConnectorType
+from common.tracing import get_logger
+
+log = get_logger("connector_hub.cli")
+
+CLI_CAPABILITIES = [
+    Capability(
+        name="agent_invoke",
+        description="Send a message to the PiAgent and get a response",
+        input_schema={
+            "type": "object",
+            "properties": {
+                "message": {"type": "string", "description": "Message to send to the agent"},
+                "session_id": {"type": "string", "description": "Optional session ID"},
+            },
+            "required": ["message"],
+        },
+        output_schema={"type": "object"},
+        idempotent=True,
+        risk_level="medium",
+    ),
+]
+
+
+class CliConnector(Connector):
+    """Connector that wraps PiAgentClient subprocess/CLI calls.
+
+    This is the primary connector for pi-agent invocation, reusing the
+    existing PiAgentClient from apps.runtime.
+    """
+
+    def __init__(
+        self,
+        connector_id: str = "piagent-cli",
+        name: str = "PiAgent CLI",
+        description: str = "PiAgent via subprocess CLI — wraps OpenClaw agent invocation",
+        default_agent: str = "chat",
+        default_timeout_seconds: int = 120,
+    ) -> None:
+        self._id = connector_id
+        self._name = name
+        self._description = description
+        self._default_agent = default_agent
+        self._default_timeout = default_timeout_seconds
+
+    @property
+    def id(self) -> str:
+        return self._id
+
+    @property
+    def name(self) -> str:
+        return self._name
+
+    @property
+    def description(self) -> str:
+        return self._description
+
+    @property
+    def type(self) -> ConnectorType:
+        return ConnectorType.CLI
+
+    def list_capabilities(self) -> list[Capability]:
+        return CLI_CAPABILITIES
+
+    async def invoke(
+        self,
+        capability: str,
+        parameters: dict[str, Any],
+        timeout_seconds: int = 120,
+    ) -> Any:
+        if capability != "agent_invoke":
+            raise ConnectorCapabilityNotFoundError(self.id, capability)
+
+        message = parameters.get("message")
+        if not message:
+            raise ConnectorExecutionFailedError(self.id, reason="Missing required parameter: message")
+
+        session_id = parameters.get("session_id")
+
+        # Import lazily to avoid circular import at module level
+        from apps.runtime.piagent_client import PiAgentClient
+
+        client = PiAgentClient(
+            agent_id=self._default_agent,
+            timeout_seconds=timeout_seconds,
+        )
+
+        start = time.monotonic()
+        try:
+            result = await asyncio.wait_for(
+                client.invoke_async(message, session_id=session_id),
+                timeout=timeout_seconds,
+            )
+            duration_ms = int((time.monotonic() - start) * 1000)
+            return {
+                "run_id": result.run_id,
+                "status": result.status,
+                "summary": result.summary,
+                "text": result.text,
+                "duration_ms": duration_ms,
+            }
+        except asyncio.TimeoutError:
+            raise ConnectorTimeoutError(self.id, timeout_seconds) from None
+
+    async def health_check(self) -> bool:
+        try:
+            from apps.runtime.piagent_client import PiAgentClient
+
+            client = PiAgentClient(agent_id=self._default_agent, timeout_seconds=5)
+            # Lightweight smoke test: just try to invoke with a ping
+            result = await asyncio.wait_for(
+                client.invoke_async("ping", session_id=None),
+                timeout=5,
+            )
+            return result.status == "ok"
+        except Exception as e:
+            log.warning("cli_connector.health_check.failed", error=str(e))
+            return False

--- a/apps/connector_hub/errors.py
+++ b/apps/connector_hub/errors.py
@@ -1,0 +1,93 @@
+"""ConnectorHub errors — re-export 4xxx codes from common/errors."""
+
+from __future__ import annotations
+
+from typing import Any, Optional
+
+from common.errors import ErrorCode
+
+# Re-export 4xxx error codes from common.errors
+CONNECTOR_NOT_FOUND = ErrorCode.CONNECTOR_NOT_FOUND
+CONNECTOR_CAPABILITY_NOT_FOUND = ErrorCode.CONNECTOR_CAPABILITY_NOT_FOUND
+CONNECTOR_EXECUTION_FAILED = ErrorCode.CONNECTOR_EXECUTION_FAILED
+CONNECTOR_TIMEOUT = ErrorCode.CONNECTOR_TIMEOUT
+CONNECTOR_UNHEALTHY = ErrorCode.CONNECTOR_UNHEALTHY
+
+
+class ConnectorHubError(Exception):
+    """Base exception for ConnectorHub errors."""
+
+    def __init__(
+        self,
+        message: str,
+        code: ErrorCode = ErrorCode.CONNECTOR_EXECUTION_FAILED,
+        connector_id: Optional[str] = None,
+        capability: Optional[str] = None,
+        **extra: Any,
+    ):
+        super().__init__(message)
+        self.message = message
+        self.code = code
+        self.connector_id = connector_id
+        self.capability = capability
+
+
+class ConnectorNotFoundError(ConnectorHubError):
+    """Raised when a connector ID is not found in the registry."""
+
+    def __init__(self, connector_id: str, **extra: Any):
+        super().__init__(
+            f"Connector not found: {connector_id}",
+            code=ErrorCode.CONNECTOR_NOT_FOUND,
+            connector_id=connector_id,
+            **extra,
+        )
+
+
+class ConnectorCapabilityNotFoundError(ConnectorHubError):
+    """Raised when a connector does not have the requested capability."""
+
+    def __init__(self, connector_id: str, capability: str, **extra: Any):
+        super().__init__(
+            f"Capability '{capability}' not found on connector '{connector_id}'",
+            code=ErrorCode.CONNECTOR_CAPABILITY_NOT_FOUND,
+            connector_id=connector_id,
+            capability=capability,
+            **extra,
+        )
+
+
+class ConnectorExecutionFailedError(ConnectorHubError):
+    """Raised when connector invocation fails."""
+
+    def __init__(self, connector_id: str, reason: str, **extra: Any):
+        super().__init__(
+            f"Connector '{connector_id}' execution failed: {reason}",
+            code=ErrorCode.CONNECTOR_EXECUTION_FAILED,
+            connector_id=connector_id,
+            **extra,
+        )
+
+
+class ConnectorTimeoutError(ConnectorHubError):
+    """Raised when connector invocation times out."""
+
+    def __init__(self, connector_id: str, timeout_seconds: int, **extra: Any):
+        super().__init__(
+            f"Connector '{connector_id}' timed out after {timeout_seconds}s",
+            code=ErrorCode.CONNECTOR_TIMEOUT,
+            connector_id=connector_id,
+            **extra,
+        )
+
+
+class ConnectorHealthError(ConnectorHubError):
+    """Raised when a connector health check fails."""
+
+    def __init__(self, connector_id: str, reason: str, **extra: Any):
+        super().__init__(
+            f"Connector '{connector_id}' is unhealthy: {reason}",
+            code=ErrorCode.CONNECTOR_UNHEALTHY,
+            connector_id=connector_id,
+            **extra,
+        )

--- a/apps/connector_hub/main.py
+++ b/apps/connector_hub/main.py
@@ -1,0 +1,141 @@
+"""ConnectorHub FastAPI service — port 8003."""
+
+from __future__ import annotations
+
+import time
+from contextlib import asynccontextmanager
+from datetime import datetime, timezone
+
+from fastapi import FastAPI, HTTPException
+
+from apps.connector_hub import __version__
+from apps.connector_hub.config import ConnectorHubSettings
+from apps.connector_hub.errors import ConnectorHubError
+from apps.connector_hub.models import (
+    ConnectorListResponse,
+    HubHealthResponse,
+    InvokeRequest,
+    InvokeResponse,
+)
+from apps.connector_hub.registry import _auto_register, get, list_all, list_ids
+from common.tracing import get_logger
+
+log = get_logger("connector_hub")
+
+settings = ConnectorHubSettings()
+
+
+@asynccontextmanager
+async def lifespan(app: FastAPI):
+    _auto_register()
+    log.info(
+        "connector_hub.started",
+        port=settings.port,
+        connectors=list_ids(),
+    )
+    yield
+    log.info("connector_hub.stopped")
+
+
+app = FastAPI(title="ConnectorHub", version=__version__, lifespan=lifespan)
+
+
+@app.get("/connector-hub/health", response_model=HubHealthResponse)
+async def hub_health() -> HubHealthResponse:
+    """Overall health of ConnectorHub and its connectors."""
+    from apps.connector_hub.registry import get_info_map
+
+    info_map = get_info_map()
+    all_healthy = all(info_map.values()) if info_map else True
+    return HubHealthResponse(
+        status="healthy" if all_healthy else "degraded",
+        version=__version__,
+        timestamp=datetime.now(timezone.utc),
+        connectors=info_map,
+    )
+
+
+@app.get("/connectors", response_model=ConnectorListResponse)
+async def list_connectors() -> ConnectorListResponse:
+    """Return all registered connectors with their capabilities."""
+    connectors = list_all()
+    return ConnectorListResponse(
+        connectors=[c.to_info() for c in connectors],
+        total=len(connectors),
+    )
+
+
+@app.post("/connectors/{connector_id}/invoke", response_model=InvokeResponse)
+async def invoke_connector(
+    connector_id: str,
+    req: InvokeRequest,
+) -> InvokeResponse:
+    """Invoke a capability on a registered connector."""
+    start = time.monotonic()
+
+    try:
+        connector = get(connector_id)
+    except KeyError:
+        raise HTTPException(status_code=404, detail=f"Connector not found: {connector_id}")
+
+    timeout = req.timeout_seconds or settings.default_timeout_seconds
+
+    try:
+        result = await connector.invoke(
+            capability=req.capability,
+            parameters=req.parameters,
+            timeout_seconds=timeout,
+        )
+        duration_ms = int((time.monotonic() - start) * 1000)
+        return InvokeResponse(
+            connector_id=connector_id,
+            capability=req.capability,
+            result=result,
+            duration_ms=duration_ms,
+        )
+
+    except ConnectorHubError as e:
+        log.warning(
+            "connector.invoke.failed",
+            connector_id=connector_id,
+            capability=req.capability,
+            code=e.code,
+            error=e.message,
+        )
+        duration_ms = int((time.monotonic() - start) * 1000)
+        return InvokeResponse(
+            connector_id=connector_id,
+            capability=req.capability,
+            duration_ms=duration_ms,
+            error=e.message,
+        )
+
+
+@app.get("/connectors/{connector_id}/health")
+async def connector_health(connector_id: str) -> dict:
+    """Check health of a specific connector."""
+    try:
+        connector = get(connector_id)
+    except KeyError:
+        raise HTTPException(status_code=404, detail=f"Connector not found: {connector_id}")
+
+    start = time.monotonic()
+    try:
+        healthy = await connector.health_check()
+    except Exception as e:
+        duration_ms = int((time.monotonic() - start) * 1000)
+        return {
+            "connector_id": connector_id,
+            "healthy": False,
+            "latency_ms": duration_ms,
+            "error": str(e),
+            "timestamp": datetime.now(timezone.utc).isoformat(),
+        }
+
+    duration_ms = int((time.monotonic() - start) * 1000)
+    return {
+        "connector_id": connector_id,
+        "healthy": healthy,
+        "latency_ms": duration_ms,
+        "timestamp": datetime.now(timezone.utc).isoformat(),
+    }

--- a/apps/connector_hub/models.py
+++ b/apps/connector_hub/models.py
@@ -1,0 +1,100 @@
+"""ConnectorHub request/response models."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from enum import Enum
+from typing import Any, Dict, List, Optional
+
+from pydantic import BaseModel, Field
+
+
+class ConnectorType(str, Enum):
+    """Connector type (priority order)."""
+
+    CLI = "cli"
+    MCP = "mcp"
+    API = "api"
+    CU = "cu"  # Custom
+
+
+class Capability(BaseModel):
+    """Single capability of a connector."""
+
+    name: str
+    description: str
+    input_schema: Optional[Dict[str, Any]] = None
+    output_schema: Optional[Dict[str, Any]] = None
+    idempotent: bool = True
+    risk_level: str = "low"  # low / medium / high
+    requires_approval: bool = False
+
+    model_config = {"extra": "ignore"}
+
+
+class ConnectorInfo(BaseModel):
+    """Registered connector descriptor."""
+
+    id: str
+    name: str
+    description: str = ""
+    type: ConnectorType
+    capabilities: List[Capability] = Field(default_factory=list)
+    healthy: bool = True
+    config: Dict[str, Any] = Field(default_factory=dict)
+    created_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
+
+    model_config = {"extra": "ignore"}
+
+
+class ConnectorListResponse(BaseModel):
+    """Response for GET /connectors."""
+
+    connectors: List[ConnectorInfo]
+    total: int
+
+
+class InvokeRequest(BaseModel):
+    """Request for POST /connectors/{id}/invoke."""
+
+    capability: str = Field(..., description="Capability name to invoke")
+    parameters: Dict[str, Any] = Field(default_factory=dict)
+    timeout_seconds: Optional[int] = Field(None, ge=1, le=600)
+    employee_id: Optional[str] = None
+
+    model_config = {"extra": "ignore"}
+
+
+class InvokeResponse(BaseModel):
+    """Response for POST /connectors/{id}/invoke."""
+
+    connector_id: str
+    capability: str
+    result: Any = None
+    duration_ms: int = 0
+    error: Optional[str] = None
+
+    model_config = {"extra": "ignore"}
+
+
+class HealthResponse(BaseModel):
+    """Response for GET /connectors/{id}/health."""
+
+    connector_id: str
+    healthy: bool
+    latency_ms: int = 0
+    error: Optional[str] = None
+    timestamp: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
+
+    model_config = {"extra": "ignore"}
+
+
+class HubHealthResponse(BaseModel):
+    """Response for GET /connector-hub/health."""
+
+    status: str = "healthy"
+    version: str
+    timestamp: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
+    connectors: Dict[str, bool] = Field(default_factory=dict)
+
+    model_config = {"extra": "ignore"}

--- a/apps/connector_hub/registry.py
+++ b/apps/connector_hub/registry.py
@@ -1,0 +1,53 @@
+"""ConnectorHub registry — manages connector lifecycle and discovery."""
+
+from __future__ import annotations
+
+from typing import Dict, List
+
+from apps.connector_hub.connectors.base import Connector
+from apps.connector_hub.connectors.cli import CliConnector
+from common.tracing import get_logger
+
+log = get_logger("connector_hub.registry")
+
+# Global registry: connector_id -> Connector instance
+_registry: Dict[str, Connector] = {}
+
+
+def register(connector: Connector) -> None:
+    """Register a connector in the global registry."""
+    if connector.id in _registry:
+        log.warning("connector.already_registered", connector_id=connector.id)
+    _registry[connector.id] = connector
+    log.info("connector.registered", connector_id=connector.id, type=connector.type.value)
+
+
+def get(connector_id: str) -> Connector:
+    """Get a connector by ID. Raises KeyError if not found."""
+    return _registry[connector_id]
+
+
+def list_all() -> List[Connector]:
+    """Return all registered connectors."""
+    return list(_registry.values())
+
+
+def list_ids() -> List[str]:
+    """Return IDs of all registered connectors."""
+    return list(_registry.keys())
+
+
+def get_info_map() -> Dict[str, bool]:
+    """Return {connector_id: healthy} for all connectors."""
+    return {cid: c.to_info().healthy for cid, c in _registry.items()}
+
+
+def is_registered(connector_id: str) -> bool:
+    """Return True if connector is registered."""
+    return connector_id in _registry
+
+
+def _auto_register() -> None:
+    """Auto-register built-in connectors."""
+    register(CliConnector())
+    log.info("connector_hub.auto_registered", count=len(_registry))

--- a/tests/unit/apps/test_connector_hub/test_cli_connector.py
+++ b/tests/unit/apps/test_connector_hub/test_cli_connector.py
@@ -1,0 +1,98 @@
+"""ConnectorHub CLI connector unit tests."""
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from apps.connector_hub.connectors.cli import CliConnector
+from apps.connector_hub.errors import ConnectorCapabilityNotFoundError, ConnectorTimeoutError
+from apps.connector_hub.models import ConnectorType
+
+
+class TestCliConnector:
+    """CliConnector tests."""
+
+    def test_properties(self):
+        """Connector exposes correct id, name, type."""
+        c = CliConnector()
+        assert c.id == "piagent-cli"
+        assert c.name == "PiAgent CLI"
+        assert c.type == ConnectorType.CLI
+        assert "agent_invoke" in [cap.name for cap in c.list_capabilities()]
+
+    def test_custom_id_and_name(self):
+        """Custom connector_id and name are respected."""
+        c = CliConnector(
+            connector_id="my-agent",
+            name="My Custom Agent",
+        )
+        assert c.id == "my-agent"
+        assert c.name == "My Custom Agent"
+
+    def test_to_info(self):
+        """to_info returns ConnectorInfo with correct fields."""
+        c = CliConnector()
+        info = c.to_info()
+        assert info.id == "piagent-cli"
+        assert info.type == ConnectorType.CLI
+        assert len(info.capabilities) == 1
+        assert info.capabilities[0].name == "agent_invoke"
+
+    @pytest.mark.asyncio
+    async def test_invoke_unknown_capability_raises(self):
+        """Unknown capability raises ConnectorCapabilityNotFoundError."""
+        c = CliConnector()
+        with pytest.raises(ConnectorCapabilityNotFoundError):
+            await c.invoke("unknown_cap", {})
+
+    @pytest.mark.asyncio
+    async def test_invoke_missing_message_raises(self):
+        """agent_invoke without message raises."""
+        c = CliConnector()
+        with pytest.raises(Exception):  # ExecutionFailed
+            await c.invoke("agent_invoke", parameters={})
+
+    @pytest.mark.asyncio
+    async def test_invoke_success(self):
+        """Successful invocation returns result dict."""
+        c = CliConnector()
+
+        mock_result = AsyncMock()
+        mock_result.run_id = "run-123"
+        mock_result.status = "ok"
+        mock_result.summary = "Done"
+        mock_result.text = "Hello!"
+
+        with patch(
+            "apps.runtime.piagent_client.PiAgentClient"
+        ) as MockClient:
+            mock_instance = AsyncMock()
+            mock_instance.invoke_async.return_value = mock_result
+            MockClient.return_value = mock_instance
+
+            result = await c.invoke(
+                "agent_invoke",
+                parameters={"message": "hello"},
+                timeout_seconds=30,
+            )
+
+        assert result["run_id"] == "run-123"
+        assert result["status"] == "ok"
+
+    @pytest.mark.asyncio
+    async def test_invoke_timeout_raises_ConnectorTimeoutError(self):
+        """Timeout raises ConnectorTimeoutError."""
+        c = CliConnector()
+
+        import asyncio
+
+        with patch(
+            "apps.runtime.piagent_client.PiAgentClient"
+        ) as MockClient:
+            mock_instance = AsyncMock()
+            mock_instance.invoke_async.side_effect = asyncio.TimeoutError()
+            MockClient.return_value = mock_instance
+
+            with pytest.raises(ConnectorTimeoutError):
+                await c.invoke("agent_invoke", parameters={"message": "hi"})

--- a/tests/unit/apps/test_connector_hub/test_registry.py
+++ b/tests/unit/apps/test_connector_hub/test_registry.py
@@ -1,0 +1,70 @@
+"""ConnectorHub registry unit tests."""
+from __future__ import annotations
+
+import pytest
+
+from apps.connector_hub.connectors.cli import CliConnector
+from apps.connector_hub.models import Capability, ConnectorType
+from apps.connector_hub.registry import (
+    _auto_register,
+    get,
+    is_registered,
+    list_all,
+    list_ids,
+    register,
+)
+
+
+class DummyConnector(CliConnector):
+    """Test-only connector that doesn't require external deps."""
+
+    def __init__(self, cid: str = "dummy"):
+        super().__init__(connector_id=cid, name=f"Dummy {cid}")
+
+
+def _reset_registry():
+    """Clear the global registry between tests."""
+    import apps.connector_hub.registry as reg
+
+    reg._registry.clear()
+
+
+class TestRegistry:
+    """Registry tests."""
+
+    def test_register_and_get(self):
+        _reset_registry()
+        c = DummyConnector("test-1")
+        register(c)
+        assert get("test-1").id == "test-1"
+
+    def test_register_duplicate_warns(self):
+        _reset_registry()
+        c = DummyConnector("dup")
+        register(c)
+        # Second registration logs warning but doesn't raise
+        register(c)
+        assert list_ids() == ["dup"]
+
+    def test_list_all(self):
+        _reset_registry()
+        register(DummyConnector("a"))
+        register(DummyConnector("b"))
+        ids = list_ids()
+        assert set(ids) == {"a", "b"}
+
+    def test_is_registered(self):
+        _reset_registry()
+        assert not is_registered("ghost")
+        register(DummyConnector("ghost"))
+        assert is_registered("ghost")
+
+    def test_get_unknown_raises_KeyError(self):
+        _reset_registry()
+        with pytest.raises(KeyError):
+            get("nonexistent")
+
+    def test_auto_register_adds_piagent_cli(self):
+        _reset_registry()
+        _auto_register()
+        assert "piagent-cli" in list_ids()


### PR DESCRIPTION
## Summary
- **ConnectorHub FastAPI service** (port 8003) with:
  - `GET /connectors` — list all registered connectors
  - `POST /connectors/{id}/invoke` — invoke a capability
  - `GET /connectors/{id}/health` — per-connector health
  - `GET /connector-hub/health` — overall hub status
- **CliConnector** — wraps `PiAgentClient` for `agent_invoke` capability
- **Registry** — global connector registration with auto-register on startup
- **Error codes**: 4xxx from `common/errors` (ConnectorHubError hierarchy)
- 13 unit tests

## Architecture
Connectors are prioritized: CLI > MCP > API > CU/BU. Only CLI (PiAgent) is implemented in this PR; MCP and API connectors are TODO.

## Test plan
- [x] `ruff check apps/connector_hub/ && mypy apps/connector_hub/`
- [x] `pytest tests/unit/apps/test_connector_hub/ -v` (13 passed)
- [ ] Manual: start sidecar, call `/connectors/piagent-cli/invoke` with `{"capability": "agent_invoke", "parameters": {"message": "ping"}}`

🤖 Generated with [Claude Code](https://claude.com/claude-code)