### PR TITLE
feat(skill_hub): SkillHub — skill registry with lifecycle management

### DIFF
--- a/apps/skill_hub/__init__.py
+++ b/apps/skill_hub/__init__.py
@@ -1,4 +1,5 @@
 """SkillHub — skill registry and lifecycle management."""
+
 from __future__ import annotations
 
 __version__ = "0.1.0"

--- a/apps/skill_hub/__init__.py
+++ b/apps/skill_hub/__init__.py
@@ -1,0 +1,4 @@
+"""SkillHub — skill registry and lifecycle management."""
+from __future__ import annotations
+
+__version__ = "0.1.0"

--- a/apps/skill_hub/config.py
+++ b/apps/skill_hub/config.py
@@ -1,4 +1,5 @@
 """SkillHub configuration."""
+
 from __future__ import annotations
 
 from common.config import BaseSettings

--- a/apps/skill_hub/config.py
+++ b/apps/skill_hub/config.py
@@ -1,0 +1,14 @@
+"""SkillHub configuration."""
+from __future__ import annotations
+
+from common.config import BaseSettings
+
+
+class SkillHubSettings(BaseSettings):
+    """SkillHub settings."""
+
+    model_config = {"env_prefix": "SKILLHUB_", "extra": "ignore"}
+
+    host: str = "127.0.0.1"
+    port: int = 8004
+    default_timeout_seconds: int = 120

--- a/apps/skill_hub/errors.py
+++ b/apps/skill_hub/errors.py
@@ -1,0 +1,72 @@
+"""SkillHub errors — 5xxx codes from common/errors."""
+from __future__ import annotations
+
+from typing import Any, Optional
+
+from common.errors import ErrorCode
+
+# Re-export 5xxx error codes
+SKILL_NOT_FOUND = ErrorCode.SKILL_NOT_FOUND
+SKILL_INVOCATION_FAILED = ErrorCode.SKILL_INVOCATION_FAILED
+SKILL_NOT_APPLICABLE = ErrorCode.SKILL_NOT_APPLICABLE
+SKILL_DEPRECATED = ErrorCode.SKILL_DEPRECATED
+
+
+class SkillHubError(Exception):
+    """Base exception for SkillHub errors."""
+
+    def __init__(
+        self,
+        message: str,
+        code: ErrorCode = ErrorCode.SKILL_INVOCATION_FAILED,
+        skill_id: Optional[str] = None,
+        **extra: Any,
+    ):
+        super().__init__(message)
+        self.message = message
+        self.code = code
+        self.skill_id = skill_id
+
+
+class SkillNotFoundError(SkillHubError):
+    """Raised when a skill ID is not found."""
+
+    def __init__(self, skill_id: str):
+        super().__init__(
+            f"Skill not found: {skill_id}",
+            code=ErrorCode.SKILL_NOT_FOUND,
+            skill_id=skill_id,
+        )
+
+
+class SkillInvocationFailedError(SkillHubError):
+    """Raised when skill invocation fails."""
+
+    def __init__(self, skill_id: str, reason: str):
+        super().__init__(
+            f"Skill '{skill_id}' invocation failed: {reason}",
+            code=ErrorCode.SKILL_INVOCATION_FAILED,
+            skill_id=skill_id,
+        )
+
+
+class SkillNotApplicableError(SkillHubError):
+    """Raised when a skill is not applicable to the current task."""
+
+    def __init__(self, skill_id: str, reason: str):
+        super().__init__(
+            f"Skill '{skill_id}' not applicable: {reason}",
+            code=ErrorCode.SKILL_NOT_APPLICABLE,
+            skill_id=skill_id,
+        )
+
+
+class SkillDeprecatedError(SkillHubError):
+    """Raised when attempting to invoke a deprecated skill."""
+
+    def __init__(self, skill_id: str):
+        super().__init__(
+            f"Skill '{skill_id}' is deprecated",
+            code=ErrorCode.SKILL_DEPRECATED,
+            skill_id=skill_id,
+        )

--- a/apps/skill_hub/errors.py
+++ b/apps/skill_hub/errors.py
@@ -1,4 +1,5 @@
 """SkillHub errors — 5xxx codes from common/errors."""
+
 from __future__ import annotations
 
 from typing import Any, Optional

--- a/apps/skill_hub/main.py
+++ b/apps/skill_hub/main.py
@@ -1,4 +1,5 @@
 """SkillHub FastAPI service — port 8004."""
+
 from __future__ import annotations
 
 import time

--- a/apps/skill_hub/main.py
+++ b/apps/skill_hub/main.py
@@ -1,0 +1,140 @@
+"""SkillHub FastAPI service — port 8004."""
+from __future__ import annotations
+
+import time
+from contextlib import asynccontextmanager
+from datetime import datetime, timezone
+from typing import Optional
+
+from fastapi import FastAPI, HTTPException
+
+from apps.skill_hub import __version__
+from apps.skill_hub.config import SkillHubSettings
+from apps.skill_hub.errors import SkillHubError
+from apps.skill_hub.models import (
+    InvokeRequest,
+    InvokeResponse,
+    RegisterSkillRequest,
+    Skill,
+    SkillHubHealthResponse,
+    SkillLevel,
+    SkillListResponse,
+    SkillStatus,
+    TransitionRequest,
+)
+from apps.skill_hub.registry import (
+    _auto_seed,
+    get,
+    list_all,
+    register,
+    update_status,
+)
+from common.tracing import get_logger
+
+log = get_logger("skill_hub")
+
+settings = SkillHubSettings()
+
+
+@asynccontextmanager
+async def lifespan(app: FastAPI):
+    _auto_seed()
+    log.info("skill_hub.started", port=settings.port, skill_count=len(list_all()))
+    yield
+    log.info("skill_hub.stopped")
+
+
+app = FastAPI(title="SkillHub", version=__version__, lifespan=lifespan)
+
+
+@app.get("/skill-hub/health", response_model=SkillHubHealthResponse)
+async def hub_health() -> SkillHubHealthResponse:
+    """Overall health of SkillHub."""
+    return SkillHubHealthResponse(
+        status="healthy",
+        version=__version__,
+        timestamp=datetime.now(timezone.utc),
+        skill_count=len(list_all()),
+    )
+
+
+@app.get("/skills", response_model=SkillListResponse)
+async def list_skills(
+    status: Optional[str] = None,
+    level: Optional[str] = None,
+) -> SkillListResponse:
+    """List all registered skills, optionally filtered."""
+    status_filter = SkillStatus(status) if status else None
+    level_filter = SkillLevel(level) if level else None
+    skills = list_all(status=status_filter, level=level_filter)
+    return SkillListResponse(skills=skills, total=len(skills))
+
+
+@app.post("/skills", response_model=Skill, status_code=201)
+async def register_skill(req: RegisterSkillRequest) -> Skill:
+    """Register a new skill."""
+    skill = Skill(
+        id=req.id,
+        name=req.name,
+        description=req.description,
+        level=req.level,
+        capabilities=req.capabilities,
+        agent_families=req.agent_families,
+        status=SkillStatus.DRAFT,
+    )
+    register(skill)
+    log.info("skill.registered", skill_id=skill.id)
+    return skill
+
+
+@app.get("/skills/{skill_id}", response_model=Skill)
+async def get_skill(skill_id: str) -> Skill:
+    """Get a skill by ID."""
+    try:
+        return get(skill_id)
+    except KeyError:
+        raise HTTPException(status_code=404, detail=f"Skill not found: {skill_id}")
+
+
+@app.post("/skills/{skill_id}/transition", response_model=Skill)
+async def transition_skill(
+    skill_id: str,
+    req: TransitionRequest,
+) -> Skill:
+    """Transition a skill to a new lifecycle status."""
+    try:
+        return update_status(skill_id, req.target_status)
+    except SkillHubError as e:
+        raise HTTPException(status_code=400, detail=e.message) from e
+
+
+@app.post("/skills/{skill_id}/invoke", response_model=InvokeResponse)
+async def invoke_skill(
+    skill_id: str,
+    req: InvokeRequest,
+) -> InvokeResponse:
+    """Invoke a skill by ID."""
+    start = time.monotonic()
+
+    try:
+        skill = get(skill_id)
+    except KeyError:
+        raise HTTPException(status_code=404, detail=f"Skill not found: {skill_id}")
+
+    if SkillStatus(skill.status) == SkillStatus.DEPRECATED:
+        log.warning("skill.invoke.deprecated", skill_id=skill_id)
+        return InvokeResponse(
+            skill_id=skill_id,
+            duration_ms=int((time.monotonic() - start) * 1000),
+            error=f"Skill '{skill_id}' is deprecated",
+        )
+
+    duration_ms = int((time.monotonic() - start) * 1000)
+
+    # Skill invocation is currently a stub — actual invocation would call
+    # the ConnectorHub or external system. This returns a structured response.
+    return InvokeResponse(
+        skill_id=skill_id,
+        result={"status": "not_implemented", "message": f"Skill '{skill_id}' invoke not yet connected"},
+        duration_ms=duration_ms,
+    )

--- a/apps/skill_hub/models.py
+++ b/apps/skill_hub/models.py
@@ -1,0 +1,113 @@
+"""SkillHub request/response models."""
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from enum import Enum
+from typing import Any, Dict, List, Optional
+
+from pydantic import BaseModel, Field
+
+
+class SkillLevel(str, Enum):
+    """Skill tier / level."""
+
+    L1 = "L1"  # Enterprise通用技能
+    L2 = "L2"  # 岗位专用技能
+    L3 = "L3"  # 场景临时技能
+
+
+class SkillStatus(str, Enum):
+    """Skill lifecycle status."""
+
+    DRAFT = "draft"
+    TESTING = "testing"
+    STAGING = "staging"
+    PUBLISHED = "published"
+    DEPRECATED = "deprecated"
+
+
+# Valid lifecycle transitions
+VALID_TRANSITIONS: dict[SkillStatus, list[SkillStatus]] = {
+    SkillStatus.DRAFT: [SkillStatus.TESTING],
+    SkillStatus.TESTING: [SkillStatus.STAGING, SkillStatus.DRAFT],
+    SkillStatus.STAGING: [SkillStatus.PUBLISHED, SkillStatus.TESTING],
+    SkillStatus.PUBLISHED: [SkillStatus.DEPRECATED],
+    SkillStatus.DEPRECATED: [],  # Terminal state
+}
+
+
+class Skill(BaseModel):
+    """Skill descriptor — mirrors common.models.Skill."""
+
+    id: str
+    name: str
+    description: str = ""
+    level: SkillLevel = SkillLevel.L2
+    version: str = "1.0"
+    capabilities: List[Any] = Field(default_factory=list)  # re-export SkillCapability from common
+    agent_families: List[str] = Field(default_factory=list)
+    status: SkillStatus = SkillStatus.DRAFT
+    created_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
+    updated_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
+
+    model_config = {"use_enum_values": True, "extra": "ignore"}
+
+
+class RegisterSkillRequest(BaseModel):
+    """Request to register a new skill."""
+
+    id: str = Field(..., description="Unique skill ID")
+    name: str
+    description: str = ""
+    level: SkillLevel = SkillLevel.L2
+    capabilities: List[Any] = Field(default_factory=list)
+    agent_families: List[str] = Field(default_factory=list)
+
+    model_config = {"extra": "ignore"}
+
+
+class SkillListResponse(BaseModel):
+    """Response for GET /skills."""
+
+    skills: List[Skill]
+    total: int
+
+
+class InvokeRequest(BaseModel):
+    """Request to invoke a skill."""
+
+    parameters: Dict[str, Any] = Field(default_factory=dict)
+    timeout_seconds: Optional[int] = Field(None, ge=1, le=600)
+    employee_id: Optional[str] = None
+
+    model_config = {"extra": "ignore"}
+
+
+class InvokeResponse(BaseModel):
+    """Response for skill invocation."""
+
+    skill_id: str
+    result: Any = None
+    duration_ms: int = 0
+    error: Optional[str] = None
+
+    model_config = {"extra": "ignore"}
+
+
+class TransitionRequest(BaseModel):
+    """Request to transition skill lifecycle status."""
+
+    target_status: SkillStatus
+
+    model_config = {"extra": "ignore"}
+
+
+class SkillHubHealthResponse(BaseModel):
+    """Response for GET /skill-hub/health."""
+
+    status: str = "healthy"
+    version: str
+    timestamp: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
+    skill_count: int = 0
+
+    model_config = {"extra": "ignore"}

--- a/apps/skill_hub/models.py
+++ b/apps/skill_hub/models.py
@@ -1,4 +1,5 @@
 """SkillHub request/response models."""
+
 from __future__ import annotations
 
 from datetime import datetime, timezone

--- a/apps/skill_hub/registry.py
+++ b/apps/skill_hub/registry.py
@@ -1,4 +1,5 @@
 """SkillHub registry — manages skill lifecycle and discovery."""
+
 from __future__ import annotations
 
 from datetime import datetime, timezone

--- a/apps/skill_hub/registry.py
+++ b/apps/skill_hub/registry.py
@@ -1,0 +1,119 @@
+"""SkillHub registry — manages skill lifecycle and discovery."""
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any, Dict, List, Optional
+
+from apps.skill_hub.errors import SkillHubError, SkillNotFoundError
+from apps.skill_hub.models import (
+    VALID_TRANSITIONS,
+    Skill,
+    SkillLevel,
+    SkillStatus,
+)
+from common.models import SkillCapability
+from common.tracing import get_logger
+
+log = get_logger("skill_hub.registry")
+
+# Global registry: skill_id -> Skill
+_registry: Dict[str, Skill] = {}
+
+
+def register(skill: Skill) -> None:
+    """Register a skill in the global registry."""
+    if skill.id in _registry:
+        log.warning("skill.already_registered", skill_id=skill.id)
+    _registry[skill.id] = skill
+    log.info("skill.registered", skill_id=skill.id, level=skill.level)
+
+
+def get(skill_id: str) -> Skill:
+    """Get a skill by ID."""
+    if skill_id not in _registry:
+        raise SkillNotFoundError(skill_id)
+    return _registry[skill_id]
+
+
+def list_all(
+    status: Optional[SkillStatus] = None,
+    level: Optional[SkillLevel] = None,
+) -> List[Skill]:
+    """List all skills, optionally filtered."""
+    skills = list(_registry.values())
+    if status is not None:
+        skills = [s for s in skills if s.status == status]
+    if level is not None:
+        skills = [s for s in skills if s.level == level]
+    return skills
+
+
+def update_status(skill_id: str, target: SkillStatus) -> Skill:
+    """Transition a skill to a new lifecycle status."""
+    skill = get(skill_id)
+    current = SkillStatus(skill.status)
+    allowed = VALID_TRANSITIONS.get(current, [])
+
+    if target not in allowed:
+        raise SkillHubError(
+            f"Invalid transition: {current.value} → {target.value}",
+            skill_id=skill_id,
+        )
+
+    skill.status = target
+    skill.updated_at = datetime.now(timezone.utc)
+    log.info("skill.status_changed", skill_id=skill_id, from_=current.value, to=target.value)
+    return skill
+
+
+def _auto_seed() -> None:
+    """Seed the registry with built-in L1 skills."""
+    for skill_def in _BUILTIN_SKILLS:
+        skill = Skill(
+            id=str(skill_def["id"]),
+            name=str(skill_def["name"]),
+            description=str(skill_def["description"]),
+            level=SkillLevel.L1,
+            status=SkillStatus.PUBLISHED,
+            capabilities=[
+                SkillCapability(
+                    name=str(c["name"]),
+                    description=str(c["description"]),
+                    idempotent=c.get("idempotent", True),
+                )
+                for c in skill_def.get("capabilities", [])
+            ],
+        )
+        register(skill)
+    log.info("skill_hub.seeded", count=len(_BUILTIN_SKILLS))
+
+
+_BUILTIN_SKILLS: List[Dict[str, Any]] = [
+    {
+        "id": "builtin-approval",
+        "name": "审批流程",
+        "description": "企业审批流程 — 请假、报销、采购等",
+        "capabilities": [
+            {"name": "submit_approval", "description": "提交审批申请"},
+            {"name": "query_status", "description": "查询审批状态"},
+        ],
+    },
+    {
+        "id": "builtin-notification",
+        "name": "企业通知",
+        "description": "飞书/邮件/短信多渠道通知",
+        "capabilities": [
+            {"name": "send_message", "description": "发送通知消息"},
+            {"name": "send_bulk", "description": "批量发送通知"},
+        ],
+    },
+    {
+        "id": "builtin-email",
+        "name": "邮件处理",
+        "description": "邮件读取、发送、搜索",
+        "capabilities": [
+            {"name": "send_email", "description": "发送邮件"},
+            {"name": "search_emails", "description": "搜索邮件"},
+        ],
+    },
+]

--- a/tests/unit/apps/test_skill_hub/test_registry.py
+++ b/tests/unit/apps/test_skill_hub/test_registry.py
@@ -1,0 +1,74 @@
+"""SkillHub registry and lifecycle tests."""
+from __future__ import annotations
+
+import pytest
+
+from apps.skill_hub.errors import SkillHubError, SkillNotFoundError
+from apps.skill_hub.models import Skill, SkillLevel, SkillStatus
+from apps.skill_hub.registry import (
+    get,
+    list_all,
+    register,
+    update_status,
+)
+
+
+def _reset():
+    import apps.skill_hub.registry as reg
+    reg._registry.clear()
+
+
+class TestSkillRegistry:
+    """Registry tests."""
+
+    def test_register_and_get(self):
+        _reset()
+        s = Skill(id="test-skill", name="Test Skill", level=SkillLevel.L2)
+        register(s)
+        assert get("test-skill").id == "test-skill"
+
+    def test_get_unknown_raises(self):
+        _reset()
+        with pytest.raises(SkillNotFoundError):
+            get("ghost")
+
+    def test_list_all_filters_by_status(self):
+        _reset()
+        register(Skill(id="a", name="A", status=SkillStatus.PUBLISHED))
+        register(Skill(id="b", name="B", status=SkillStatus.DRAFT))
+        result = list_all(status=SkillStatus.PUBLISHED)
+        assert len(result) == 1
+        assert result[0].id == "a"
+
+
+class TestLifecycleTransitions:
+    """Lifecycle state machine tests."""
+
+    def test_draft_to_testing_ok(self):
+        _reset()
+        s = Skill(id="t1", name="T1", status=SkillStatus.DRAFT)
+        register(s)
+        updated = update_status("t1", SkillStatus.TESTING)
+        assert updated.status == SkillStatus.TESTING
+
+    def test_draft_to_deprecated_invalid(self):
+        _reset()
+        s = Skill(id="t2", name="T2", status=SkillStatus.DRAFT)
+        register(s)
+        with pytest.raises(SkillHubError) as exc:
+            update_status("t2", SkillStatus.DEPRECATED)
+        assert "Invalid transition" in exc.value.message
+
+    def test_published_to_deprecated_ok(self):
+        _reset()
+        s = Skill(id="t3", name="T3", status=SkillStatus.PUBLISHED)
+        register(s)
+        updated = update_status("t3", SkillStatus.DEPRECATED)
+        assert updated.status == SkillStatus.DEPRECATED
+
+    def test_deprecated_is_terminal(self):
+        _reset()
+        s = Skill(id="t4", name="T4", status=SkillStatus.DEPRECATED)
+        register(s)
+        with pytest.raises(SkillHubError):
+            update_status("t4", SkillStatus.DRAFT)

--- a/tests/unit/apps/test_skill_hub/test_registry.py
+++ b/tests/unit/apps/test_skill_hub/test_registry.py
@@ -1,4 +1,5 @@
 """SkillHub registry and lifecycle tests."""
+
 from __future__ import annotations
 
 import pytest
@@ -15,6 +16,7 @@ from apps.skill_hub.registry import (
 
 def _reset():
     import apps.skill_hub.registry as reg
+
     reg._registry.clear()
 
 


### PR DESCRIPTION
## Summary
- **SkillHub FastAPI service** (port 8004):
  - `GET /skills` — list skills (filter by status/level)
  - `POST /skills` — register a new skill
  - `GET /skills/{id}` — skill details
  - `POST /skills/{id}/transition` — lifecycle state transitions
  - `POST /skills/{id}/invoke` — skill invocation (stub; actual invocation connects to ConnectorHub)
- **Lifecycle state machine**: DRAFT → TESTING → STAGING → PUBLISHED → DEPRECATED with enforced transitions
- **Built-in L1 skills** (auto-seeded): approval, notification, email
- **5xxx error codes** from common/errors

## Test plan
- [x] `ruff check apps/skill_hub/ && mypy apps/skill_hub/`
- [x] `pytest tests/unit/apps/test_skill_hub/ -v` (7 passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)