### PR TITLE
feat(ops): OPS_API_KEY auto-generation and management

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -30,3 +30,8 @@ KNOWLEDGE_RAG_ENABLED=true
 
 # -------------------- Logging --------------------
 LOG_LEVEL=INFO
+
+# -------------------- Ops API --------------------
+# Ops API authentication key (optional — auto-generated on first startup if not set)
+# Generate via: POST /api/admin/api-key (requires existing key or dev mode)
+OPS_API_KEY=

--- a/apps/ops/db.py
+++ b/apps/ops/db.py
@@ -112,6 +112,14 @@ def init_db():
         summary TEXT,
         created_at TEXT       -- ISO timestamp
     );
+
+    CREATE TABLE IF NOT EXISTS api_keys (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        key_hash TEXT NOT NULL,
+        created_at TEXT NOT NULL,
+        description TEXT DEFAULT '',
+        is_active INTEGER NOT NULL DEFAULT 1
+    );
     """)
     conn.commit()
     conn.close()

--- a/apps/ops/key_manager.py
+++ b/apps/ops/key_manager.py
@@ -1,0 +1,126 @@
+"""OPS API Key Manager — auto-generation, storage, and verification."""
+
+from __future__ import annotations
+
+import hashlib
+import os
+import secrets
+import sqlite3
+import time
+from pathlib import Path
+from typing import Optional
+
+from common.tracing import get_logger
+
+logger = get_logger("ops.key_manager")
+
+
+def hash_key(key: str) -> str:
+    """SHA-256 hash of the API key."""
+    return hashlib.sha256(key.encode()).hexdigest()
+
+
+def generate_key() -> str:
+    """Generate a 64-char hex key (32 bytes)."""
+    return secrets.token_hex(32)
+
+
+class OPSKeyManager:
+    def __init__(self, db_path: Optional[str] = None):
+        self.db_path: str = db_path or os.environ.get("OPS_DB_PATH", "data/ops.db")
+        self._ensure_db()
+
+    def _ensure_db(self) -> None:
+        Path(self.db_path).parent.mkdir(parents=True, exist_ok=True)
+
+    def init_db(self) -> None:
+        """Create api_keys table if not exists."""
+        conn = sqlite3.connect(self.db_path)
+        conn.execute(
+            """
+            CREATE TABLE IF NOT EXISTS api_keys (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                key_hash TEXT NOT NULL,
+                created_at TEXT NOT NULL,
+                description TEXT DEFAULT '',
+                is_active INTEGER NOT NULL DEFAULT 1
+            )
+            """
+        )
+        conn.commit()
+        conn.close()
+
+    def is_dev_mode(self) -> bool:
+        """Dev mode: no OPS_API_KEY env var AND no active key in DB."""
+        if os.environ.get("OPS_API_KEY"):
+            return False
+        conn = sqlite3.connect(self.db_path)
+        cur = conn.cursor()
+        cur.execute("SELECT COUNT(*) FROM api_keys WHERE is_active = 1")
+        count = cur.fetchone()[0]
+        conn.close()
+        return count == 0
+
+    def get_active_key_hash(self) -> Optional[str]:
+        """Get the active key hash from DB, or None."""
+        conn = sqlite3.connect(self.db_path)
+        cur = conn.cursor()
+        cur.execute("SELECT key_hash FROM api_keys WHERE is_active = 1 LIMIT 1")
+        row = cur.fetchone()
+        conn.close()
+        return row[0] if row else None
+
+    def verify_key(self, key: str) -> bool:
+        """Timing-safe verification. Returns True if key matches active key."""
+        env_key = os.environ.get("OPS_API_KEY", "")
+        if env_key:
+            return secrets.compare_digest(key, env_key)
+
+        # Otherwise check DB
+        active_hash = self.get_active_key_hash()
+        if not active_hash:
+            return True  # Dev mode - allow all
+
+        return secrets.compare_digest(hash_key(key), active_hash)
+
+    def generate_and_store(self, description: str = "") -> str:
+        """Generate new key, store hash, return plaintext key ONCE."""
+        key = generate_key()
+        h = hash_key(key)
+        conn = sqlite3.connect(self.db_path)
+        # Deactivate all existing keys
+        conn.execute("UPDATE api_keys SET is_active = 0 WHERE is_active = 1")
+        conn.execute(
+            "INSERT INTO api_keys (key_hash, created_at, description, is_active) VALUES (?, ?, ?, 1)",
+            (h, time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()), description),
+        )
+        conn.commit()
+        conn.close()
+        logger.info("api_key_generated", description=description)
+        return key
+
+    def get_active_key_hint(self) -> Optional[str]:
+        """Return a hint like 'key_****_8chars' or 'env:OPS_API_KEY'."""
+        env_key = os.environ.get("OPS_API_KEY", "")
+        if env_key:
+            return f"env:OPS_API_KEY (last 4: {env_key[-4:]})"
+        active_hash = self.get_active_key_hash()
+        if active_hash:
+            return f"db:****{active_hash[-6:]}"
+        return None
+
+    def ensure_key_exists(self) -> None:
+        """On startup: if no env var AND no active DB key, auto-generate."""
+        if os.environ.get("OPS_API_KEY"):
+            return
+        if self.get_active_key_hash():
+            return
+        self.generate_and_store("auto-generated on first startup")
+        logger.warning(
+            "api_key_auto_generated",
+            hint=self.get_active_key_hint(),
+            instruction=(
+                "Set OPS_API_KEY env var for production use, or use POST /api/admin/api-key "
+                "to generate a new key. Current key stored in DB."
+            ),
+        )

--- a/apps/ops/main.py
+++ b/apps/ops/main.py
@@ -46,6 +46,7 @@ def _force_dev_mode() -> None:
     global _key_manager
     if _key_manager is not None:
         import sqlite3
+
         conn = sqlite3.connect(_key_manager.db_path)
         conn.execute("UPDATE api_keys SET is_active = 0 WHERE is_active = 1")
         conn.commit()

--- a/apps/ops/main.py
+++ b/apps/ops/main.py
@@ -31,11 +31,33 @@ def get_key_manager() -> OPSKeyManager:
     return _key_manager
 
 
+def _init_key_manager(db_path: str) -> None:
+    """Initialize the key manager with the given DB path. Idempotent — skips if already initialized."""
+    global _key_manager
+    if _key_manager is not None:
+        return
+    _key_manager = OPSKeyManager(db_path=db_path)
+    _key_manager.init_db()
+    _key_manager.ensure_key_exists()
+
+
+def _force_dev_mode() -> None:
+    """Force dev mode by deactivating any active DB key. For test use only."""
+    global _key_manager
+    if _key_manager is not None:
+        import sqlite3
+        conn = sqlite3.connect(_key_manager.db_path)
+        conn.execute("UPDATE api_keys SET is_active = 0 WHERE is_active = 1")
+        conn.commit()
+        conn.close()
+
+
 def verify_api_key(x_api_key: str = Header(default="")):
-    km = get_key_manager()
-    if km.is_dev_mode():
+    if _key_manager is None:
+        return True  # Uninitialized = dev mode
+    if _key_manager.is_dev_mode():
         return True
-    if not km.verify_key(x_api_key):
+    if not _key_manager.verify_key(x_api_key):
         raise HTTPException(status_code=401, detail="Invalid API key")
     return True
 

--- a/apps/ops/main.py
+++ b/apps/ops/main.py
@@ -5,7 +5,7 @@ import subprocess
 import threading
 import time
 from pathlib import Path
-from typing import Any, Dict
+from typing import Any, Dict, Optional
 
 from fastapi import Depends, FastAPI, Header, HTTPException
 from fastapi.middleware.cors import CORSMiddleware
@@ -18,16 +18,24 @@ from .db import (
     init_db,
     record_execution,
 )
+from .key_manager import OPSKeyManager
 from .openclaw_registry import OpenclawAgentRegistry
 
-OPS_API_KEY = os.environ.get("OPS_API_KEY", "")
+_key_manager: Optional[OPSKeyManager] = None
+
+
+def get_key_manager() -> OPSKeyManager:
+    global _key_manager
+    if _key_manager is None:
+        raise RuntimeError("Key manager not initialized")
+    return _key_manager
 
 
 def verify_api_key(x_api_key: str = Header(default="")):
-    if not OPS_API_KEY:
-        # If no OPS_API_KEY is set, allow access (dev mode)
+    km = get_key_manager()
+    if km.is_dev_mode():
         return True
-    if x_api_key != OPS_API_KEY:
+    if not km.verify_key(x_api_key):
         raise HTTPException(status_code=401, detail="Invalid API key")
     return True
 
@@ -202,6 +210,12 @@ def _demo_scheduler():
 
 @app.on_event("startup")
 def startup():
+    global _key_manager
+    db_path = os.environ.get("OPS_DB_PATH", "data/ops.db")
+    _key_manager = OPSKeyManager(db_path=db_path)
+    _key_manager.init_db()
+    _key_manager.ensure_key_exists()
+
     init_db()
 
     # Ensure seed blueprint agents exist in openclaw dirs
@@ -244,6 +258,27 @@ def _ensure_seed_agents():
 def shutdown():
     global _runner_active
     _runner_active = False
+
+
+# ── Admin: API Key Management ────────────────────────────────
+
+
+@app.post("/api/admin/api-key")
+def create_api_key(req: dict, _: bool = Depends(verify_api_key)):
+    """Generate a new API key. Returns the plaintext key ONCE — store it securely."""
+    description = req.get("description", "")
+    key = get_key_manager().generate_and_store(description)
+    return {
+        "key": key,
+        "hint": get_key_manager().get_active_key_hint(),
+        "warning": "This key is shown only once. Store it securely.",
+    }
+
+
+@app.get("/api/admin/api-key/hint")
+def get_api_key_hint(_: bool = Depends(verify_api_key)):
+    """Get a hint about the current active key (no secrets exposed)."""
+    return {"hint": get_key_manager().get_active_key_hint()}
 
 
 # ── Dashboard ────────────────────────────────────────────────

--- a/tests/integration/test_ops_api.py
+++ b/tests/integration/test_ops_api.py
@@ -52,6 +52,9 @@ def client(db_path):
     from apps.ops.main import app
 
     with TestClient(app) as c:
+        # After startup fires (which init'd key manager for this module instance),
+        # force dev mode so tests don't need API keys
+        ops_main._force_dev_mode()
         yield c
 
 

--- a/tests/unit/apps/ops/test_deploy_agent_sync.py
+++ b/tests/unit/apps/ops/test_deploy_agent_sync.py
@@ -5,7 +5,7 @@ from fastapi.testclient import TestClient
 
 
 def _init_test_db(tmp_path, monkeypatch):
-    """Set up the temp DB with schema before TestClient triggers startup()."""
+    """Set up the temp DB with schema and key manager before TestClient triggers startup()."""
     monkeypatch.setenv("OPS_DB_PATH", str(tmp_path / "ops.db"))
     monkeypatch.setattr("apps.ops.db.DB_PATH", str(tmp_path / "ops.db"))
     # Force DB_PATH recompute by reloading the module-level variable
@@ -17,6 +17,13 @@ def _init_test_db(tmp_path, monkeypatch):
     init_db()
     conn = get_db()
     conn.close()
+
+    # Initialize key manager so endpoints don't raise "Key manager not initialized"
+    from apps.ops import main as ops_main
+
+    ops_main._init_key_manager(str(tmp_path / "ops.db"))
+    # Force dev mode so tests don't need API keys
+    ops_main._force_dev_mode()
 
 
 def test_deploy_creates_openclaw_agent(tmp_path, monkeypatch):

--- a/tests/unit/apps/ops/test_execute_routes_to_blueprint.py
+++ b/tests/unit/apps/ops/test_execute_routes_to_blueprint.py
@@ -7,7 +7,7 @@ from fastapi.testclient import TestClient
 
 
 def _init_test_db(tmp_path, monkeypatch):
-    """Set up the temp DB with schema before TestClient triggers startup()."""
+    """Set up the temp DB with schema and key manager before TestClient triggers startup()."""
     monkeypatch.setenv("OPS_DB_PATH", str(tmp_path / "ops.db"))
     monkeypatch.setenv("PIAGENT_CLI_STUB", "true")
     from apps.ops import db as db_module
@@ -18,6 +18,13 @@ def _init_test_db(tmp_path, monkeypatch):
     init_db()
     conn = get_db()
     conn.close()
+
+    # Initialize key manager so endpoints don't raise "Key manager not initialized"
+    from apps.ops import main as ops_main
+
+    ops_main._init_key_manager(str(tmp_path / "ops.db"))
+    # Force dev mode so tests don't need API keys
+    ops_main._force_dev_mode()
 
 
 def test_execute_uses_blueprint_id_param(tmp_path, monkeypatch):

--- a/tests/unit/apps/ops/test_key_manager.py
+++ b/tests/unit/apps/ops/test_key_manager.py
@@ -1,0 +1,165 @@
+"""Tests for apps.ops.key_manager."""
+import os
+import tempfile
+
+import pytest
+
+from apps.ops.key_manager import OPSKeyManager, generate_key, hash_key
+
+
+class TestHashKey:
+    def test_hash_key_deterministic(self):
+        assert hash_key("test") == hash_key("test")
+        assert hash_key("test") != hash_key("other")
+
+    def test_hash_key_length(self):
+        result = hash_key("any-key")
+        assert len(result) == 64  # SHA-256 = 64 hex chars
+
+
+class TestGenerateKey:
+    def test_generate_key_length(self):
+        key = generate_key()
+        assert len(key) == 64  # 32 bytes = 64 hex chars
+
+    def test_generate_key_uniqueness(self):
+        keys = {generate_key() for _ in range(100)}
+        assert len(keys) == 100  # All unique
+
+
+class TestOPSKeyManager:
+    @pytest.fixture
+    def db_path(self):
+        with tempfile.NamedTemporaryFile(suffix=".db", delete=False) as f:
+            yield f.name
+        os.unlink(f.name)
+
+    @pytest.fixture
+    def km(self, db_path):
+        os.environ.pop("OPS_API_KEY", None)
+        km = OPSKeyManager(db_path=db_path)
+        km.init_db()
+        return km
+
+    def test_is_dev_mode_true_when_no_key(self, km):
+        """Dev mode when no env var and no DB key."""
+        os.environ.pop("OPS_API_KEY", None)
+        assert km.is_dev_mode() is True
+
+    def test_is_dev_mode_false_with_env_var(self, db_path):
+        """Not dev mode when OPS_API_KEY env var is set."""
+        os.environ["OPS_API_KEY"] = "my-secret-key"
+        try:
+            km = OPSKeyManager(db_path=db_path)
+            km.init_db()
+            assert km.is_dev_mode() is False
+        finally:
+            os.environ.pop("OPS_API_KEY", None)
+
+    def test_dev_mode_allows_any_key(self, km):
+        """In dev mode, any key is accepted."""
+        assert km.verify_key("anything") is True
+        assert km.verify_key("something-else") is True
+
+    def test_verify_key_with_env_var(self, db_path):
+        """Env var key is verified correctly."""
+        os.environ["OPS_API_KEY"] = "my-secret-key"
+        try:
+            km = OPSKeyManager(db_path=db_path)
+            km.init_db()
+            assert km.verify_key("my-secret-key") is True
+            assert km.verify_key("wrong") is False
+        finally:
+            os.environ.pop("OPS_API_KEY", None)
+
+    def test_generate_and_store(self, km):
+        """generate_and_store returns plaintext key and stores hash."""
+        key = km.generate_and_store("test key")
+        assert len(key) == 64
+        # Key should now work
+        assert km.verify_key(key) is True
+        assert km.verify_key("wrong") is False
+
+    def test_generate_and_store_deactivates_old_keys(self, km):
+        """Generating a new key deactivates the previous one."""
+        key1 = km.generate_and_store("first key")
+        key2 = km.generate_and_store("second key")
+
+        # Both hashes are stored, but only key2 is active
+        conn = __import__("sqlite3").connect(km.db_path)
+        cur = conn.cursor()
+        cur.execute("SELECT COUNT(*) FROM api_keys WHERE is_active = 1")
+        active_count = cur.fetchone()[0]
+        conn.close()
+
+        assert active_count == 1
+        assert km.verify_key(key2) is True
+        assert km.verify_key(key1) is False  # Old key no longer works
+
+    def test_auto_gen_on_first_startup(self, db_path):
+        """ensure_key_exists auto-generates key when none exists."""
+        os.environ.pop("OPS_API_KEY", None)
+        km = OPSKeyManager(db_path=db_path)
+        km.init_db()
+
+        assert km.is_dev_mode() is True
+        assert km.get_active_key_hash() is None
+
+        km.ensure_key_exists()
+
+        # Still dev mode (no env var), but now has DB key
+        assert km.get_active_key_hash() is not None
+
+        # Verify the generated key works
+        # Can't get plaintext back, but we can verify hash is stored
+        active_hash = km.get_active_key_hash()
+        assert active_hash is not None
+        assert len(active_hash) == 64
+
+    def test_get_active_key_hint_env(self, db_path):
+        """Hint shows env:var when OPS_API_KEY is set."""
+        os.environ["OPS_API_KEY"] = "my-secret-key-1234"
+        try:
+            km = OPSKeyManager(db_path=db_path)
+            km.init_db()
+            hint = km.get_active_key_hint()
+            assert hint == "env:OPS_API_KEY (last 4: 1234)"
+        finally:
+            os.environ.pop("OPS_API_KEY", None)
+
+    def test_get_active_key_hint_db(self, km):
+        """Hint shows db:****XXXX when key is in DB."""
+        km.ensure_key_exists()
+        hint = km.get_active_key_hint()
+        assert hint is not None
+        assert hint.startswith("db:****")
+        # Format: "db:****" + last 6 chars of SHA-256 hash = 13 chars total
+        assert len(hint) == 13
+
+    def test_get_active_key_hint_none(self, km):
+        """Hint is None when no key exists."""
+        hint = km.get_active_key_hint()
+        assert hint is None
+
+    def test_ensure_key_exists_skips_when_env_var_set(self, db_path):
+        """ensure_key_exists does nothing if OPS_API_KEY env var is set."""
+        os.environ["OPS_API_KEY"] = "existing-env-key"
+        try:
+            km = OPSKeyManager(db_path=db_path)
+            km.init_db()
+            km.ensure_key_exists()
+            assert km.get_active_key_hash() is None  # No DB key created
+        finally:
+            os.environ.pop("OPS_API_KEY", None)
+
+    def test_ensure_key_exists_skips_when_db_key_exists(self, km):
+        """ensure_key_exists does nothing if DB key already exists."""
+        km.generate_and_store("manual key")
+        km.ensure_key_exists()  # Should not create another key
+
+        conn = __import__("sqlite3").connect(km.db_path)
+        cur = conn.cursor()
+        cur.execute("SELECT COUNT(*) FROM api_keys")
+        count = cur.fetchone()[0]
+        conn.close()
+        assert count == 1


### PR DESCRIPTION
## Summary
- Add `api_keys` SQLite table for persistent API key storage
- Create `apps/ops/key_manager.py` with `OPSKeyManager` class: auto-generation, SHA-256 hash storage, timing-safe verification (`secrets.compare_digest`)
- Wire into `main.py`: dev mode when no key exists, admin endpoints for key rotation
- Add 16 unit tests (all passing)
- Update `.env.example` with `OPS_API_KEY` documentation

## Key behaviors
- **Startup**: auto-generates key if no `OPS_API_KEY` env var and no DB key
- **Env var takes precedence** over DB key (backward compatible)
- **Timing-safe comparison** (no timing attacks)
- **Key rotation**: `POST /api/admin/api-key` generates new key, deactivates old
- **Hint query**: `GET /api/admin/api-key/hint` (no secrets exposed)

## Test plan
- [x] `pytest tests/unit/apps/ops/test_key_manager.py -v` — 16/16 passing
- [x] `ruff check apps/ops/` — all clean
- [x] `mypy apps/ops/` — no issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)